### PR TITLE
Add DDD event module

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,8 @@
+model = "gpt-5.5"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+
+[features]
+hooks = true
+plugin_hooks = true
+goals = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## Unreleased
+
+- Deprecated: `mediator` is now a legacy package for existing users. New domain
+  event code should use `ddd/event`; see `docs/mediator-migration.md`.
+
 ## v0.3.1
 
 - added support for `golang.org/x/exp/slog`

--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/go-jimu/components.svg)](https://pkg.go.dev/github.com/go-jimu/components)
 [![CI](https://github.com/go-jimu/components/actions/workflows/ci.yml/badge.svg)](https://github.com/go-jimu/components/actions/workflows/ci.yml)
 
+## Domain events
+
+For new domain event code, use `github.com/go-jimu/components/ddd/event`.
+
+The legacy `mediator` package remains source-compatible for existing users and
+will only receive compatibility fixes. See
+[`docs/mediator-migration.md`](docs/mediator-migration.md) for the semantic
+differences and migration guidance.

--- a/ddd/doc.go
+++ b/ddd/doc.go
@@ -1,0 +1,5 @@
+// Package ddd contains reusable components named after DDD concepts.
+//
+// The ddd directory is a component namespace, not a prescription for an
+// application's Domain Layer directory structure.
+package ddd

--- a/ddd/event/collection.go
+++ b/ddd/event/collection.go
@@ -1,0 +1,36 @@
+package event
+
+type collection struct {
+	events  []Event
+	drained bool
+}
+
+// NewCollection creates an empty aggregate event collection.
+func NewCollection() Collection {
+	return &collection{}
+}
+
+func (c *collection) Add(event Event) bool {
+	if c.drained {
+		return false
+	}
+	c.events = append(c.events, event)
+	return true
+}
+
+func (c *collection) Drain() []Event {
+	if c.drained {
+		return nil
+	}
+	c.drained = true
+	events := c.events
+	c.events = nil
+	return events
+}
+
+func (c *collection) Len() int {
+	if c.drained {
+		return 0
+	}
+	return len(c.events)
+}

--- a/ddd/event/collection_test.go
+++ b/ddd/event/collection_test.go
@@ -1,0 +1,44 @@
+package event_test
+
+import (
+	"testing"
+
+	"github.com/go-jimu/components/ddd/event"
+	"github.com/stretchr/testify/require"
+)
+
+type testEvent struct {
+	kind event.Kind
+	name string
+}
+
+func (e testEvent) Kind() event.Kind { return e.kind }
+
+// Intent: a collection should preserve aggregate-raised event order until the
+// application drains it after persistence.
+func TestCollectionAddDrainOrderAndLen(t *testing.T) {
+	collection := event.NewCollection()
+
+	require.True(t, collection.Add(testEvent{kind: "order.paid", name: "first"}))
+	require.True(t, collection.Add(testEvent{kind: "order.confirmed", name: "second"}))
+	require.Equal(t, 2, collection.Len())
+
+	drained := collection.Drain()
+
+	require.Len(t, drained, 2)
+	require.Equal(t, "first", drained[0].(testEvent).name)
+	require.Equal(t, "second", drained[1].(testEvent).name)
+	require.Equal(t, 0, collection.Len())
+}
+
+// Intent: a drained collection is closed so the same aggregate event batch
+// cannot be appended to or dispatched twice.
+func TestCollectionRejectsAddAfterDrain(t *testing.T) {
+	collection := event.NewCollection()
+	require.True(t, collection.Add(testEvent{kind: "order.paid"}))
+
+	require.Len(t, collection.Drain(), 1)
+	require.False(t, collection.Add(testEvent{kind: "order.confirmed"}))
+	require.Empty(t, collection.Drain())
+	require.Equal(t, 0, collection.Len())
+}

--- a/ddd/event/dispatcher.go
+++ b/ddd/event/dispatcher.go
@@ -1,0 +1,248 @@
+package event
+
+import (
+	"context"
+	"log/slog"
+	"runtime/debug"
+	"sync"
+	"time"
+)
+
+const (
+	defaultBufferSize = 1024
+	defaultDelayClose = 5 * time.Second
+)
+
+type batch struct {
+	events []Event
+}
+
+type dispatcher struct {
+	mu                    sync.Mutex
+	notEmpty              *sync.Cond
+	notFull               *sync.Cond
+	queue                 []batch
+	closed                bool
+	done                  chan struct{}
+	handlers              map[Kind][]Handler
+	logger                *slog.Logger
+	delayClose            time.Duration
+	handlerTimeout        time.Duration
+	contextFactory        func(context.Context, Event) context.Context
+	unhandledEventHandler func(Event)
+	panicHandler          func(Event, any, []byte)
+	bufferSize            int
+	rootCtx               context.Context
+	rootCancel            context.CancelFunc
+}
+
+var _ Dispatcher = (*dispatcher)(nil)
+
+// NewDispatcher creates an in-process dispatcher with one background worker.
+func NewDispatcher(opts ...Option) Dispatcher {
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+	d := &dispatcher{
+		done:       make(chan struct{}),
+		handlers:   make(map[Kind][]Handler),
+		logger:     slog.Default(),
+		delayClose: defaultDelayClose,
+		bufferSize: defaultBufferSize,
+		rootCtx:    rootCtx,
+		rootCancel: rootCancel,
+	}
+	d.notEmpty = sync.NewCond(&d.mu)
+	d.notFull = sync.NewCond(&d.mu)
+
+	for _, opt := range opts {
+		opt(d)
+	}
+
+	go d.run()
+	return d
+}
+
+func (d *dispatcher) Subscribe(handler Handler) {
+	if handler == nil {
+		return
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.closed {
+		return
+	}
+	for _, kind := range handler.Listening() {
+		d.handlers[kind] = append(d.handlers[kind], handler)
+	}
+}
+
+func (d *dispatcher) Dispatch(event Event) bool {
+	if event == nil {
+		return true
+	}
+	return d.DispatchAll([]Event{event})
+}
+
+func (d *dispatcher) DispatchAll(events []Event) bool {
+	if len(events) == 0 {
+		return true
+	}
+
+	copied := make([]Event, len(events))
+	copy(copied, events)
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	for len(d.queue) >= d.bufferSize && !d.closed {
+		d.notFull.Wait()
+	}
+	if d.closed {
+		return false
+	}
+
+	d.queue = append(d.queue, batch{events: copied})
+	d.notEmpty.Signal()
+	return true
+}
+
+func (d *dispatcher) Close(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	defer d.rootCancel()
+
+	if d.delayClose > 0 {
+		timer := time.NewTimer(d.delayClose)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return ctx.Err()
+		}
+	}
+
+	d.beginClose()
+
+	select {
+	case <-d.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (d *dispatcher) beginClose() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if d.closed {
+		return
+	}
+	d.closed = true
+	d.notEmpty.Broadcast()
+	d.notFull.Broadcast()
+}
+
+func (d *dispatcher) run() {
+	defer close(d.done)
+
+	for {
+		next, ok := d.nextBatch()
+		if !ok {
+			return
+		}
+		d.handleBatch(next)
+	}
+}
+
+func (d *dispatcher) nextBatch() (batch, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	for len(d.queue) == 0 && !d.closed {
+		d.notEmpty.Wait()
+	}
+	if len(d.queue) == 0 && d.closed {
+		return batch{}, false
+	}
+
+	next := d.queue[0]
+	copy(d.queue, d.queue[1:])
+	d.queue[len(d.queue)-1] = batch{}
+	d.queue = d.queue[:len(d.queue)-1]
+	d.notFull.Signal()
+	return next, true
+}
+
+func (d *dispatcher) handleBatch(next batch) {
+	for _, event := range next.events {
+		d.handleEvent(event)
+	}
+}
+
+func (d *dispatcher) handleEvent(event Event) {
+	if event == nil {
+		return
+	}
+
+	d.mu.Lock()
+	handlers := append([]Handler(nil), d.handlers[event.Kind()]...)
+	d.mu.Unlock()
+
+	if len(handlers) == 0 {
+		if d.unhandledEventHandler != nil {
+			d.unhandledEventHandler(event)
+		}
+		return
+	}
+
+	for _, handler := range handlers {
+		d.handleOne(handler, event)
+	}
+}
+
+func (d *dispatcher) handleOne(handler Handler, event Event) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			stack := debug.Stack()
+			if d.panicHandler != nil {
+				d.panicHandler(event, recovered, stack)
+				return
+			}
+			d.logger.Error("panic occurred while handling event",
+				slog.Any("event", event),
+				slog.Any("panic", recovered),
+				slog.Any("stack_trace", string(stack)))
+		}
+	}()
+
+	ctx, cancel := d.handlerContext(event)
+	defer cancel()
+	handler.Handle(ctx, event)
+}
+
+func (d *dispatcher) handlerContext(event Event) (context.Context, context.CancelFunc) {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+	if d.handlerTimeout > 0 {
+		ctx, cancel = context.WithTimeout(d.rootCtx, d.handlerTimeout)
+	} else {
+		ctx, cancel = context.WithCancel(d.rootCtx)
+	}
+
+	if d.contextFactory != nil {
+		if derived := d.contextFactory(ctx, event); derived != nil {
+			ctx = derived
+		}
+	}
+	return ctx, cancel
+}

--- a/ddd/event/dispatcher.go
+++ b/ddd/event/dispatcher.go
@@ -124,6 +124,7 @@ func (d *dispatcher) Close(ctx context.Context) error {
 				default:
 				}
 			}
+			d.beginClose()
 			return ctx.Err()
 		}
 	}

--- a/ddd/event/dispatcher.go
+++ b/ddd/event/dispatcher.go
@@ -187,37 +187,54 @@ func (d *dispatcher) interruptClose(err error) (CloseInterruptedContext, bool) {
 
 func (d *dispatcher) closeInterruptedSnapshotLocked(err error) CloseInterruptedContext {
 	snapshot := CloseInterruptedContext{
-		Error:             err,
-		PendingBatchCount: len(d.queue),
-		InFlightBatchID:   d.inFlightBatchID,
-	}
-	if len(d.queue) > 0 {
-		snapshot.PendingBatchIDs = make([]uint64, 0, len(d.queue))
+		Error:           err,
+		InFlightBatchID: d.inFlightBatchID,
 	}
 	for _, queued := range d.queue {
-		snapshot.PendingBatchIDs = append(snapshot.PendingBatchIDs, queued.id)
-		snapshot.PendingEventCount += len(queued.events)
-		for _, event := range queued.events {
-			if event == nil {
-				continue
-			}
-			snapshot.PendingEventKinds = append(snapshot.PendingEventKinds, event.Kind())
-		}
+		events := make([]Event, len(queued.events))
+		copy(events, queued.events)
+		snapshot.PendingBatches = append(snapshot.PendingBatches, PendingBatch{
+			BatchID: queued.id,
+			Events:  events,
+		})
 	}
 	return snapshot
 }
 
 func (d *dispatcher) reportCloseInterrupted(snapshot CloseInterruptedContext) {
+	pendingBatchIDs, pendingEventKinds, pendingEventCount := closeInterruptedSummary(snapshot)
 	d.logger.Warn("domain event dispatcher close interrupted",
 		slog.Any("error", snapshot.Error),
-		slog.Int("pending_batch_count", snapshot.PendingBatchCount),
-		slog.Int("pending_event_count", snapshot.PendingEventCount),
+		slog.Int("pending_batch_count", len(snapshot.PendingBatches)),
+		slog.Int("pending_event_count", pendingEventCount),
 		slog.Uint64("in_flight_batch_id", snapshot.InFlightBatchID),
-		slog.Any("pending_batch_ids", snapshot.PendingBatchIDs),
-		slog.Any("pending_event_kinds", snapshot.PendingEventKinds))
+		slog.Any("pending_batch_ids", pendingBatchIDs),
+		slog.Any("pending_event_kinds", pendingEventKinds))
 	if d.closeInterruptedHandler != nil {
 		d.closeInterruptedHandler(snapshot)
 	}
+}
+
+func closeInterruptedSummary(snapshot CloseInterruptedContext) ([]uint64, []Kind, int) {
+	var (
+		batchIDs   []uint64
+		eventKinds []Kind
+		eventCount int
+	)
+	if len(snapshot.PendingBatches) > 0 {
+		batchIDs = make([]uint64, 0, len(snapshot.PendingBatches))
+	}
+	for _, pending := range snapshot.PendingBatches {
+		batchIDs = append(batchIDs, pending.BatchID)
+		eventCount += len(pending.Events)
+		for _, event := range pending.Events {
+			if event == nil {
+				continue
+			}
+			eventKinds = append(eventKinds, event.Kind())
+		}
+	}
+	return batchIDs, eventKinds, eventCount
 }
 
 func (d *dispatcher) run() {

--- a/ddd/event/dispatcher.go
+++ b/ddd/event/dispatcher.go
@@ -19,23 +19,26 @@ type batch struct {
 }
 
 type dispatcher struct {
-	mu                    sync.Mutex
-	notEmpty              *sync.Cond
-	notFull               *sync.Cond
-	queue                 []batch
-	closed                bool
-	nextBatchID           uint64
-	done                  chan struct{}
-	handlers              map[Kind][]Handler
-	logger                *slog.Logger
-	delayClose            time.Duration
-	handlerTimeout        time.Duration
-	contextFactory        func(context.Context, Event) context.Context
-	unhandledEventHandler func(UnhandledContext)
-	panicHandler          func(PanicContext)
-	bufferSize            int
-	rootCtx               context.Context
-	rootCancel            context.CancelFunc
+	mu                      sync.Mutex
+	notEmpty                *sync.Cond
+	notFull                 *sync.Cond
+	queue                   []batch
+	closed                  bool
+	forced                  bool
+	nextBatchID             uint64
+	inFlightBatchID         uint64
+	done                    chan struct{}
+	handlers                map[Kind][]Handler
+	logger                  *slog.Logger
+	delayClose              time.Duration
+	handlerTimeout          time.Duration
+	contextFactory          func(context.Context, Event) context.Context
+	unhandledEventHandler   func(UnhandledContext)
+	panicHandler            func(PanicContext)
+	closeInterruptedHandler func(CloseInterruptedContext)
+	bufferSize              int
+	rootCtx                 context.Context
+	rootCancel              context.CancelFunc
 }
 
 var _ Dispatcher = (*dispatcher)(nil)
@@ -128,11 +131,11 @@ func (d *dispatcher) Close(ctx context.Context) error {
 				default:
 				}
 			}
-			closed := d.beginClose()
-			if closed {
+			snapshot, started := d.interruptClose(ctx.Err())
+			if started {
 				d.logger.Info("domain event dispatcher closing started")
 			}
-			d.logger.Warn("domain event dispatcher close interrupted", slog.Any("error", ctx.Err()))
+			d.reportCloseInterrupted(snapshot)
 			return ctx.Err()
 		}
 	}
@@ -149,7 +152,8 @@ func (d *dispatcher) Close(ctx context.Context) error {
 		}
 		return nil
 	case <-ctx.Done():
-		d.logger.Warn("domain event dispatcher close interrupted", slog.Any("error", ctx.Err()))
+		snapshot, _ := d.interruptClose(ctx.Err())
+		d.reportCloseInterrupted(snapshot)
 		return ctx.Err()
 	}
 }
@@ -167,6 +171,55 @@ func (d *dispatcher) beginClose() bool {
 	return true
 }
 
+func (d *dispatcher) interruptClose(err error) (CloseInterruptedContext, bool) {
+	d.mu.Lock()
+	started := !d.closed
+	d.closed = true
+	d.forced = true
+	snapshot := d.closeInterruptedSnapshotLocked(err)
+	d.notEmpty.Broadcast()
+	d.notFull.Broadcast()
+	d.mu.Unlock()
+
+	d.rootCancel()
+	return snapshot, started
+}
+
+func (d *dispatcher) closeInterruptedSnapshotLocked(err error) CloseInterruptedContext {
+	snapshot := CloseInterruptedContext{
+		Error:             err,
+		PendingBatchCount: len(d.queue),
+		InFlightBatchID:   d.inFlightBatchID,
+	}
+	if len(d.queue) > 0 {
+		snapshot.PendingBatchIDs = make([]uint64, 0, len(d.queue))
+	}
+	for _, queued := range d.queue {
+		snapshot.PendingBatchIDs = append(snapshot.PendingBatchIDs, queued.id)
+		snapshot.PendingEventCount += len(queued.events)
+		for _, event := range queued.events {
+			if event == nil {
+				continue
+			}
+			snapshot.PendingEventKinds = append(snapshot.PendingEventKinds, event.Kind())
+		}
+	}
+	return snapshot
+}
+
+func (d *dispatcher) reportCloseInterrupted(snapshot CloseInterruptedContext) {
+	d.logger.Warn("domain event dispatcher close interrupted",
+		slog.Any("error", snapshot.Error),
+		slog.Int("pending_batch_count", snapshot.PendingBatchCount),
+		slog.Int("pending_event_count", snapshot.PendingEventCount),
+		slog.Uint64("in_flight_batch_id", snapshot.InFlightBatchID),
+		slog.Any("pending_batch_ids", snapshot.PendingBatchIDs),
+		slog.Any("pending_event_kinds", snapshot.PendingEventKinds))
+	if d.closeInterruptedHandler != nil {
+		d.closeInterruptedHandler(snapshot)
+	}
+}
+
 func (d *dispatcher) run() {
 	defer close(d.done)
 
@@ -175,7 +228,9 @@ func (d *dispatcher) run() {
 		if !ok {
 			return
 		}
+		d.setInFlight(next.id)
 		d.handleBatch(next)
+		d.clearInFlight(next.id)
 	}
 }
 
@@ -185,6 +240,9 @@ func (d *dispatcher) nextBatch() (batch, bool) {
 
 	for len(d.queue) == 0 && !d.closed {
 		d.notEmpty.Wait()
+	}
+	if d.forced {
+		return batch{}, false
 	}
 	if len(d.queue) == 0 && d.closed {
 		return batch{}, false
@@ -196,6 +254,20 @@ func (d *dispatcher) nextBatch() (batch, bool) {
 	d.queue = d.queue[:len(d.queue)-1]
 	d.notFull.Signal()
 	return next, true
+}
+
+func (d *dispatcher) setInFlight(batchID uint64) {
+	d.mu.Lock()
+	d.inFlightBatchID = batchID
+	d.mu.Unlock()
+}
+
+func (d *dispatcher) clearInFlight(batchID uint64) {
+	d.mu.Lock()
+	if d.inFlightBatchID == batchID {
+		d.inFlightBatchID = 0
+	}
+	d.mu.Unlock()
 }
 
 func (d *dispatcher) handleBatch(next batch) {

--- a/ddd/event/dispatcher.go
+++ b/ddd/event/dispatcher.go
@@ -14,6 +14,7 @@ const (
 )
 
 type batch struct {
+	id     uint64
 	events []Event
 }
 
@@ -23,14 +24,15 @@ type dispatcher struct {
 	notFull               *sync.Cond
 	queue                 []batch
 	closed                bool
+	nextBatchID           uint64
 	done                  chan struct{}
 	handlers              map[Kind][]Handler
 	logger                *slog.Logger
 	delayClose            time.Duration
 	handlerTimeout        time.Duration
 	contextFactory        func(context.Context, Event) context.Context
-	unhandledEventHandler func(Event)
-	panicHandler          func(Event, any, []byte)
+	unhandledEventHandler func(UnhandledContext)
+	panicHandler          func(PanicContext)
 	bufferSize            int
 	rootCtx               context.Context
 	rootCancel            context.CancelFunc
@@ -93,17 +95,19 @@ func (d *dispatcher) DispatchAll(events []Event) bool {
 	copy(copied, events)
 
 	d.mu.Lock()
-	defer d.mu.Unlock()
-
 	for len(d.queue) >= d.bufferSize && !d.closed {
 		d.notFull.Wait()
 	}
 	if d.closed {
+		d.mu.Unlock()
+		d.logger.Warn("domain event dispatch rejected", slog.Int("event_count", len(copied)))
 		return false
 	}
 
-	d.queue = append(d.queue, batch{events: copied})
+	d.nextBatchID++
+	d.queue = append(d.queue, batch{id: d.nextBatchID, events: copied})
 	d.notEmpty.Signal()
+	d.mu.Unlock()
 	return true
 }
 
@@ -124,31 +128,43 @@ func (d *dispatcher) Close(ctx context.Context) error {
 				default:
 				}
 			}
-			d.beginClose()
+			closed := d.beginClose()
+			if closed {
+				d.logger.Info("domain event dispatcher closing started")
+			}
+			d.logger.Warn("domain event dispatcher close interrupted", slog.Any("error", ctx.Err()))
 			return ctx.Err()
 		}
 	}
 
-	d.beginClose()
+	closed := d.beginClose()
+	if closed {
+		d.logger.Info("domain event dispatcher closing started")
+	}
 
 	select {
 	case <-d.done:
+		if closed {
+			d.logger.Info("domain event dispatcher closed")
+		}
 		return nil
 	case <-ctx.Done():
+		d.logger.Warn("domain event dispatcher close interrupted", slog.Any("error", ctx.Err()))
 		return ctx.Err()
 	}
 }
 
-func (d *dispatcher) beginClose() {
+func (d *dispatcher) beginClose() bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
 	if d.closed {
-		return
+		return false
 	}
 	d.closed = true
 	d.notEmpty.Broadcast()
 	d.notFull.Broadcast()
+	return true
 }
 
 func (d *dispatcher) run() {
@@ -184,11 +200,11 @@ func (d *dispatcher) nextBatch() (batch, bool) {
 
 func (d *dispatcher) handleBatch(next batch) {
 	for _, event := range next.events {
-		d.handleEvent(event)
+		d.handleEvent(next.id, event)
 	}
 }
 
-func (d *dispatcher) handleEvent(event Event) {
+func (d *dispatcher) handleEvent(batchID uint64, event Event) {
 	if event == nil {
 		return
 	}
@@ -199,37 +215,48 @@ func (d *dispatcher) handleEvent(event Event) {
 
 	if len(handlers) == 0 {
 		if d.unhandledEventHandler != nil {
-			d.unhandledEventHandler(event)
+			d.unhandledEventHandler(UnhandledContext{BatchID: batchID, Event: event})
+		} else {
+			d.logger.Warn("domain event has no handler",
+				slog.Uint64("batch_id", batchID),
+				slog.Any("event_kind", event.Kind()))
 		}
 		return
 	}
 
 	for _, handler := range handlers {
-		d.handleOne(handler, event)
+		d.handleOne(batchID, handler, event)
 	}
 }
 
-func (d *dispatcher) handleOne(handler Handler, event Event) {
+func (d *dispatcher) handleOne(batchID uint64, handler Handler, event Event) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			stack := debug.Stack()
 			if d.panicHandler != nil {
-				d.panicHandler(event, recovered, stack)
+				d.panicHandler(PanicContext{
+					BatchID: batchID,
+					Event:   event,
+					Panic:   recovered,
+					Stack:   stack,
+				})
 				return
 			}
 			d.logger.Error("panic occurred while handling event",
+				slog.Uint64("batch_id", batchID),
+				slog.Any("event_kind", event.Kind()),
 				slog.Any("event", event),
 				slog.Any("panic", recovered),
 				slog.Any("stack_trace", string(stack)))
 		}
 	}()
 
-	ctx, cancel := d.handlerContext(event)
+	ctx, cancel := d.handlerContext(batchID, event)
 	defer cancel()
 	handler.Handle(ctx, event)
 }
 
-func (d *dispatcher) handlerContext(event Event) (context.Context, context.CancelFunc) {
+func (d *dispatcher) handlerContext(batchID uint64, event Event) (context.Context, context.CancelFunc) {
 	var (
 		ctx    context.Context
 		cancel context.CancelFunc
@@ -243,6 +270,10 @@ func (d *dispatcher) handlerContext(event Event) (context.Context, context.Cance
 	if d.contextFactory != nil {
 		if derived := d.contextFactory(ctx, event); derived != nil {
 			ctx = derived
+		} else {
+			d.logger.Warn("domain event context factory returned nil",
+				slog.Uint64("batch_id", batchID),
+				slog.Any("event_kind", event.Kind()))
 		}
 	}
 	return ctx, cancel

--- a/ddd/event/dispatcher_test.go
+++ b/ddd/event/dispatcher_test.go
@@ -157,3 +157,122 @@ func TestDispatcherHandlersRunInSubscriptionOrder(t *testing.T) {
 	require.Equal(t, "first", <-seen)
 	require.Equal(t, "second", <-seen)
 }
+
+// Intent: no-handler events are allowed, but applications can observe them
+// through an explicit hook when useful.
+func TestDispatcherUnhandledEventHook(t *testing.T) {
+	unhandled := make(chan event.Event, 1)
+	dispatcher := event.NewDispatcher(
+		event.WithDelayClose(0),
+		event.WithUnhandledEventHandler(func(ev event.Event) {
+			unhandled <- ev
+		}),
+	)
+	defer dispatcher.Close(context.Background())
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "unknown"}))
+	require.Equal(t, event.Kind("unknown"), (<-unhandled).Kind())
+}
+
+// Intent: a panic in one handler must not stop later handlers or later events
+// in the same accepted batch.
+func TestDispatcherRecoversPanicAndContinues(t *testing.T) {
+	panicked := make(chan any, 1)
+	seen := make(chan string, 2)
+	dispatcher := event.NewDispatcher(
+		event.WithDelayClose(0),
+		event.WithPanicHandler(func(_ event.Event, recovered any, _ []byte) {
+			panicked <- recovered
+		}),
+	)
+	defer dispatcher.Close(context.Background())
+
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.event"},
+		handle: func(context.Context, event.Event) {
+			panic("handler failed")
+		},
+	})
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.event"},
+		handle: func(_ context.Context, ev event.Event) {
+			seen <- ev.(testEvent).name
+		},
+	})
+
+	require.True(t, dispatcher.DispatchAll([]event.Event{
+		testEvent{kind: "order.event", name: "first"},
+		testEvent{kind: "order.event", name: "second"},
+	}))
+	require.Equal(t, "handler failed", <-panicked)
+	require.Equal(t, "first", <-seen)
+	require.Equal(t, "handler failed", <-panicked)
+	require.Equal(t, "second", <-seen)
+}
+
+type contextKey string
+
+// Intent: handler context is owned by the dispatcher, so configured context
+// values should be available without passing caller request context to Dispatch.
+func TestDispatcherContextFactory(t *testing.T) {
+	valueCh := make(chan string, 1)
+	dispatcher := event.NewDispatcher(
+		event.WithDelayClose(0),
+		event.WithContextFactory(func(ctx context.Context, _ event.Event) context.Context {
+			return context.WithValue(ctx, contextKey("trace"), "dispatcher-context")
+		}),
+	)
+	defer dispatcher.Close(context.Background())
+
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.paid"},
+		handle: func(ctx context.Context, _ event.Event) {
+			valueCh <- ctx.Value(contextKey("trace")).(string)
+		},
+	})
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.Equal(t, "dispatcher-context", <-valueCh)
+}
+
+// Intent: configured handler timeout should cancel long-running handler
+// contexts independently of the caller request lifecycle.
+func TestDispatcherHandlerTimeout(t *testing.T) {
+	done := make(chan error, 1)
+	dispatcher := event.NewDispatcher(
+		event.WithDelayClose(0),
+		event.WithHandlerTimeout(10*time.Millisecond),
+	)
+	defer dispatcher.Close(context.Background())
+
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.paid"},
+		handle: func(ctx context.Context, _ event.Event) {
+			<-ctx.Done()
+			done <- ctx.Err()
+		},
+	})
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.ErrorIs(t, <-done, context.DeadlineExceeded)
+}
+
+// Intent: Close should return the caller's timeout when accepted work does not
+// finish within the close deadline.
+func TestDispatcherCloseReturnsContextErrorOnTimeout(t *testing.T) {
+	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
+	block := make(chan struct{})
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.paid"},
+		handle: func(context.Context, event.Event) {
+			<-block
+		},
+	})
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, dispatcher.Close(ctx), context.DeadlineExceeded)
+	close(block)
+}

--- a/ddd/event/dispatcher_test.go
+++ b/ddd/event/dispatcher_test.go
@@ -2,6 +2,7 @@ package event_test
 
 import (
 	"context"
+	"log/slog"
 	"sync"
 	"testing"
 	"time"
@@ -22,6 +23,42 @@ func (h handlerFunc) Handle(ctx context.Context, ev event.Event) {
 	}
 }
 
+type logRecord struct {
+	level   slog.Level
+	message string
+	attrs   map[string]any
+}
+
+type recordingHandler struct {
+	records chan logRecord
+}
+
+func (h recordingHandler) Enabled(context.Context, slog.Level) bool {
+	return true
+}
+
+func (h recordingHandler) Handle(_ context.Context, record slog.Record) error {
+	attrs := make(map[string]any)
+	record.Attrs(func(attr slog.Attr) bool {
+		attrs[attr.Key] = attr.Value.Any()
+		return true
+	})
+	h.records <- logRecord{
+		level:   record.Level,
+		message: record.Message,
+		attrs:   attrs,
+	}
+	return nil
+}
+
+func (h recordingHandler) WithAttrs([]slog.Attr) slog.Handler {
+	return h
+}
+
+func (h recordingHandler) WithGroup(string) slog.Handler {
+	return h
+}
+
 func receiveWithin[T any](t *testing.T, name string, ch <-chan T) T {
 	t.Helper()
 
@@ -34,6 +71,11 @@ func receiveWithin[T any](t *testing.T, name string, ch <-chan T) T {
 
 	var zero T
 	return zero
+}
+
+func receiveLogWithin(t *testing.T, name string, ch <-chan logRecord) logRecord {
+	t.Helper()
+	return receiveWithin(t, name, ch)
 }
 
 // Intent: dispatch reports admission acceptance, not handler success.
@@ -71,6 +113,26 @@ func TestDispatcherRejectsAfterClose(t *testing.T) {
 
 	require.False(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
 	require.False(t, dispatcher.DispatchAll([]event.Event{testEvent{kind: "order.paid"}}))
+}
+
+// Intent: rejected dispatches happen in a background component, so they should
+// be logged as warnings with enough context to diagnose dropped batches.
+func TestDispatcherLogsRejectedDispatch(t *testing.T) {
+	records := make(chan logRecord, 4)
+	dispatcher := event.NewDispatcher(
+		event.WithDelayClose(0),
+		event.WithLogger(slog.New(recordingHandler{records: records})),
+	)
+	require.NoError(t, dispatcher.Close(context.Background()))
+
+	require.False(t, dispatcher.DispatchAll([]event.Event{testEvent{kind: "order.paid"}}))
+
+	record := receiveLogWithin(t, "rejected dispatch log", records)
+	for record.message != "domain event dispatch rejected" {
+		record = receiveLogWithin(t, "rejected dispatch log", records)
+	}
+	require.Equal(t, slog.LevelWarn, record.level)
+	require.Equal(t, int64(1), record.attrs["event_count"])
 }
 
 // Intent: canceling close during the delay phase still starts shutdown so
@@ -120,6 +182,25 @@ func TestDispatcherCloseDrainsAcceptedBatches(t *testing.T) {
 	close(release)
 	wg.Wait()
 	<-done
+}
+
+// Intent: dispatcher lifecycle is autonomous background work, so close start
+// and completion should be visible without relying on caller-side logs.
+func TestDispatcherLogsCloseLifecycle(t *testing.T) {
+	records := make(chan logRecord, 2)
+	dispatcher := event.NewDispatcher(
+		event.WithDelayClose(0),
+		event.WithLogger(slog.New(recordingHandler{records: records})),
+	)
+
+	require.NoError(t, dispatcher.Close(context.Background()))
+
+	started := receiveLogWithin(t, "close started log", records)
+	completed := receiveLogWithin(t, "close completed log", records)
+	require.Equal(t, slog.LevelInfo, started.level)
+	require.Equal(t, "domain event dispatcher closing started", started.message)
+	require.Equal(t, slog.LevelInfo, completed.level)
+	require.Equal(t, "domain event dispatcher closed", completed.message)
 }
 
 // Intent: DispatchAll submits one batch, so its events must be processed
@@ -175,28 +256,49 @@ func TestDispatcherHandlersRunInSubscriptionOrder(t *testing.T) {
 // Intent: no-handler events are allowed, but applications can observe them
 // through an explicit hook when useful.
 func TestDispatcherUnhandledEventHook(t *testing.T) {
-	unhandled := make(chan event.Event, 1)
+	unhandled := make(chan event.UnhandledContext, 1)
 	dispatcher := event.NewDispatcher(
 		event.WithDelayClose(0),
-		event.WithUnhandledEventHandler(func(ev event.Event) {
-			unhandled <- ev
+		event.WithUnhandledEventHandler(func(ctx event.UnhandledContext) {
+			unhandled <- ctx
 		}),
 	)
 	defer dispatcher.Close(context.Background())
 
 	require.True(t, dispatcher.Dispatch(testEvent{kind: "unknown"}))
-	require.Equal(t, event.Kind("unknown"), (<-unhandled).Kind())
+	ctx := receiveWithin(t, "unhandled event", unhandled)
+	require.Equal(t, uint64(1), ctx.BatchID)
+	require.Equal(t, event.Kind("unknown"), ctx.Event.Kind())
+}
+
+// Intent: unhandled events without a user hook should still be visible in
+// warning logs because they often indicate a subscription configuration issue.
+func TestDispatcherLogsUnhandledEventWithoutHook(t *testing.T) {
+	records := make(chan logRecord, 4)
+	dispatcher := event.NewDispatcher(
+		event.WithDelayClose(0),
+		event.WithLogger(slog.New(recordingHandler{records: records})),
+	)
+	defer dispatcher.Close(context.Background())
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "unknown"}))
+
+	record := receiveLogWithin(t, "unhandled event log", records)
+	require.Equal(t, slog.LevelWarn, record.level)
+	require.Equal(t, "domain event has no handler", record.message)
+	require.Equal(t, uint64(1), record.attrs["batch_id"])
+	require.Equal(t, event.Kind("unknown"), record.attrs["event_kind"])
 }
 
 // Intent: a panic in one handler must not stop later handlers or later events
 // in the same accepted batch.
 func TestDispatcherRecoversPanicAndContinues(t *testing.T) {
-	panicked := make(chan any, 1)
+	panicked := make(chan event.PanicContext, 2)
 	seen := make(chan string, 2)
 	dispatcher := event.NewDispatcher(
 		event.WithDelayClose(0),
-		event.WithPanicHandler(func(_ event.Event, recovered any, _ []byte) {
-			panicked <- recovered
+		event.WithPanicHandler(func(ctx event.PanicContext) {
+			panicked <- ctx
 		}),
 	)
 	defer dispatcher.Close(context.Background())
@@ -218,9 +320,13 @@ func TestDispatcherRecoversPanicAndContinues(t *testing.T) {
 		testEvent{kind: "order.event", name: "first"},
 		testEvent{kind: "order.event", name: "second"},
 	}))
-	require.Equal(t, "handler failed", receiveWithin(t, "panic recovery", panicked))
+	firstPanic := receiveWithin(t, "panic recovery", panicked)
+	require.Equal(t, uint64(1), firstPanic.BatchID)
+	require.Equal(t, "handler failed", firstPanic.Panic)
 	require.Equal(t, "first", receiveWithin(t, "first continued handler", seen))
-	require.Equal(t, "handler failed", receiveWithin(t, "second panic recovery", panicked))
+	secondPanic := receiveWithin(t, "second panic recovery", panicked)
+	require.Equal(t, uint64(1), secondPanic.BatchID)
+	require.Equal(t, "handler failed", secondPanic.Panic)
 	require.Equal(t, "second", receiveWithin(t, "second continued handler", seen))
 }
 
@@ -247,6 +353,37 @@ func TestDispatcherContextFactory(t *testing.T) {
 
 	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
 	require.Equal(t, "dispatcher-context", <-valueCh)
+}
+
+// Intent: a nil context from a user-provided factory is abnormal runtime
+// behavior and should be logged as a warning while preserving the base context.
+func TestDispatcherLogsNilContextFactory(t *testing.T) {
+	records := make(chan logRecord, 4)
+	handled := make(chan struct{}, 1)
+	dispatcher := event.NewDispatcher(
+		event.WithDelayClose(0),
+		event.WithLogger(slog.New(recordingHandler{records: records})),
+		event.WithContextFactory(func(context.Context, event.Event) context.Context {
+			return nil
+		}),
+	)
+	defer dispatcher.Close(context.Background())
+
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.paid"},
+		handle: func(ctx context.Context, _ event.Event) {
+			require.NotNil(t, ctx)
+			handled <- struct{}{}
+		},
+	})
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	receiveWithin(t, "handler after nil context factory", handled)
+	record := receiveLogWithin(t, "nil context factory log", records)
+	require.Equal(t, slog.LevelWarn, record.level)
+	require.Equal(t, "domain event context factory returned nil", record.message)
+	require.Equal(t, uint64(1), record.attrs["batch_id"])
+	require.Equal(t, event.Kind("order.paid"), record.attrs["event_kind"])
 }
 
 // Intent: configured handler timeout should cancel long-running handler
@@ -289,4 +426,35 @@ func TestDispatcherCloseReturnsContextErrorOnTimeout(t *testing.T) {
 	defer cancel()
 	require.ErrorIs(t, dispatcher.Close(ctx), context.DeadlineExceeded)
 	close(block)
+}
+
+// Intent: when Close cannot wait for accepted work to drain, the background
+// dispatcher should emit a warning diagnostic for operators.
+func TestDispatcherLogsCloseContextError(t *testing.T) {
+	records := make(chan logRecord, 4)
+	dispatcher := event.NewDispatcher(
+		event.WithDelayClose(0),
+		event.WithLogger(slog.New(recordingHandler{records: records})),
+	)
+	block := make(chan struct{})
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.paid"},
+		handle: func(context.Context, event.Event) {
+			<-block
+		},
+	})
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, dispatcher.Close(ctx), context.DeadlineExceeded)
+	close(block)
+
+	record := receiveLogWithin(t, "close context error log", records)
+	for record.message != "domain event dispatcher close interrupted" {
+		record = receiveLogWithin(t, "close context error log", records)
+	}
+	require.Equal(t, slog.LevelWarn, record.level)
+	require.ErrorIs(t, record.attrs["error"].(error), context.DeadlineExceeded)
 }

--- a/ddd/event/dispatcher_test.go
+++ b/ddd/event/dispatcher_test.go
@@ -22,6 +22,20 @@ func (h handlerFunc) Handle(ctx context.Context, ev event.Event) {
 	}
 }
 
+func receiveWithin[T any](t *testing.T, name string, ch <-chan T) T {
+	t.Helper()
+
+	select {
+	case value := <-ch:
+		return value
+	case <-time.After(500 * time.Millisecond):
+		t.Fatalf("timed out waiting for %s", name)
+	}
+
+	var zero T
+	return zero
+}
+
 // Intent: dispatch reports admission acceptance, not handler success.
 func TestDispatcherDispatchAcceptedWhileOpen(t *testing.T) {
 	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
@@ -204,10 +218,10 @@ func TestDispatcherRecoversPanicAndContinues(t *testing.T) {
 		testEvent{kind: "order.event", name: "first"},
 		testEvent{kind: "order.event", name: "second"},
 	}))
-	require.Equal(t, "handler failed", <-panicked)
-	require.Equal(t, "first", <-seen)
-	require.Equal(t, "handler failed", <-panicked)
-	require.Equal(t, "second", <-seen)
+	require.Equal(t, "handler failed", receiveWithin(t, "panic recovery", panicked))
+	require.Equal(t, "first", receiveWithin(t, "first continued handler", seen))
+	require.Equal(t, "handler failed", receiveWithin(t, "second panic recovery", panicked))
+	require.Equal(t, "second", receiveWithin(t, "second continued handler", seen))
 }
 
 type contextKey string

--- a/ddd/event/dispatcher_test.go
+++ b/ddd/event/dispatcher_test.go
@@ -59,6 +59,18 @@ func TestDispatcherRejectsAfterClose(t *testing.T) {
 	require.False(t, dispatcher.DispatchAll([]event.Event{testEvent{kind: "order.paid"}}))
 }
 
+// Intent: canceling close during the delay phase still starts shutdown so
+// future non-empty batches cannot be admitted after Close returns.
+func TestDispatcherRejectsAfterDelayCloseCancel(t *testing.T) {
+	dispatcher := event.NewDispatcher(event.WithDelayClose(time.Hour))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.ErrorIs(t, dispatcher.Close(ctx), context.Canceled)
+
+	require.False(t, dispatcher.DispatchAll([]event.Event{testEvent{kind: "order.paid"}}))
+}
+
 // Intent: close waits for already accepted work to finish before returning.
 func TestDispatcherCloseDrainsAcceptedBatches(t *testing.T) {
 	dispatcher := event.NewDispatcher(event.WithDelayClose(0))

--- a/ddd/event/dispatcher_test.go
+++ b/ddd/event/dispatcher_test.go
@@ -1,0 +1,97 @@
+package event_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-jimu/components/ddd/event"
+	"github.com/stretchr/testify/require"
+)
+
+type handlerFunc struct {
+	kinds  []event.Kind
+	handle func(context.Context, event.Event)
+}
+
+func (h handlerFunc) Listening() []event.Kind { return h.kinds }
+func (h handlerFunc) Handle(ctx context.Context, ev event.Event) {
+	if h.handle != nil {
+		h.handle(ctx, ev)
+	}
+}
+
+// Intent: dispatch reports admission acceptance, not handler success.
+func TestDispatcherDispatchAcceptedWhileOpen(t *testing.T) {
+	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
+	defer dispatcher.Close(context.Background())
+
+	called := make(chan event.Event, 1)
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.paid"},
+		handle: func(_ context.Context, ev event.Event) {
+			called <- ev
+		},
+	})
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.Equal(t, event.Kind("order.paid"), (<-called).Kind())
+}
+
+// Intent: empty batches have no domain facts to process and should be accepted
+// without waking handlers.
+func TestDispatcherDispatchAllEmptyBatchAccepted(t *testing.T) {
+	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
+	defer dispatcher.Close(context.Background())
+
+	require.True(t, dispatcher.DispatchAll(nil))
+	require.True(t, dispatcher.DispatchAll([]event.Event{}))
+}
+
+// Intent: once the dispatcher is closed, new event batches are rejected with
+// false instead of reporting handler errors.
+func TestDispatcherRejectsAfterClose(t *testing.T) {
+	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
+	require.NoError(t, dispatcher.Close(context.Background()))
+
+	require.False(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.False(t, dispatcher.DispatchAll([]event.Event{testEvent{kind: "order.paid"}}))
+}
+
+// Intent: close waits for already accepted work to finish before returning.
+func TestDispatcherCloseDrainsAcceptedBatches(t *testing.T) {
+	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.paid"},
+		handle: func(context.Context, event.Event) {
+			close(started)
+			<-release
+			close(done)
+		},
+	})
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	<-started
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		require.NoError(t, dispatcher.Close(context.Background()))
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("handler finished before release")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(release)
+	wg.Wait()
+	<-done
+}

--- a/ddd/event/dispatcher_test.go
+++ b/ddd/event/dispatcher_test.go
@@ -432,6 +432,7 @@ func TestDispatcherCloseReturnsContextErrorOnTimeout(t *testing.T) {
 // dispatcher should emit a warning diagnostic for operators.
 func TestDispatcherLogsCloseContextError(t *testing.T) {
 	records := make(chan logRecord, 4)
+	started := make(chan struct{})
 	dispatcher := event.NewDispatcher(
 		event.WithDelayClose(0),
 		event.WithLogger(slog.New(recordingHandler{records: records})),
@@ -440,10 +441,13 @@ func TestDispatcherLogsCloseContextError(t *testing.T) {
 	dispatcher.Subscribe(handlerFunc{
 		kinds: []event.Kind{"order.paid"},
 		handle: func(context.Context, event.Event) {
+			close(started)
 			<-block
 		},
 	})
 
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	<-started
 	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
@@ -457,4 +461,92 @@ func TestDispatcherLogsCloseContextError(t *testing.T) {
 	}
 	require.Equal(t, slog.LevelWarn, record.level)
 	require.ErrorIs(t, record.attrs["error"].(error), context.DeadlineExceeded)
+	require.Equal(t, int64(1), record.attrs["pending_batch_count"])
+	require.Equal(t, int64(1), record.attrs["pending_event_count"])
+	require.Equal(t, uint64(1), record.attrs["in_flight_batch_id"])
+	require.Equal(t, []uint64{2}, record.attrs["pending_batch_ids"])
+	require.Equal(t, []event.Kind{event.Kind("order.paid")}, record.attrs["pending_event_kinds"])
+}
+
+// Intent: when shutdown runs out of time, callers should receive a diagnostic
+// snapshot of accepted work that the dispatcher could not confirm as handled.
+func TestDispatcherCloseInterruptedHookReportsAbandonedWork(t *testing.T) {
+	interrupted := make(chan event.CloseInterruptedContext, 1)
+	firstStarted := make(chan struct{})
+	block := make(chan struct{})
+	dispatcher := event.NewDispatcher(
+		event.WithDelayClose(0),
+		event.WithCloseInterruptedHandler(func(ctx event.CloseInterruptedContext) {
+			interrupted <- ctx
+		}),
+	)
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.event"},
+		handle: func(context.Context, event.Event) {
+			select {
+			case <-firstStarted:
+			default:
+				close(firstStarted)
+			}
+			<-block
+		},
+	})
+
+	require.True(t, dispatcher.DispatchAll([]event.Event{
+		testEvent{kind: "order.event", name: "first"},
+		testEvent{kind: "order.event", name: "second"},
+	}))
+	<-firstStarted
+	require.True(t, dispatcher.DispatchAll([]event.Event{
+		testEvent{kind: "order.event", name: "third"},
+	}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, dispatcher.Close(ctx), context.DeadlineExceeded)
+	close(block)
+
+	snapshot := receiveWithin(t, "close interrupted hook", interrupted)
+	require.ErrorIs(t, snapshot.Error, context.DeadlineExceeded)
+	require.Equal(t, 1, snapshot.PendingBatchCount)
+	require.Equal(t, 1, snapshot.PendingEventCount)
+	require.Equal(t, uint64(1), snapshot.InFlightBatchID)
+	require.Equal(t, []uint64{2}, snapshot.PendingBatchIDs)
+	require.Equal(t, []event.Kind{"order.event"}, snapshot.PendingEventKinds)
+}
+
+// Intent: after Close times out during process shutdown, queued batches should
+// be abandoned instead of starting more handler work with canceled contexts.
+func TestDispatcherCloseTimeoutStopsTakingQueuedBatches(t *testing.T) {
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondStarted := make(chan struct{}, 1)
+	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.event"},
+		handle: func(_ context.Context, ev event.Event) {
+			switch ev.(testEvent).name {
+			case "first":
+				close(firstStarted)
+				<-releaseFirst
+			case "second":
+				secondStarted <- struct{}{}
+			}
+		},
+	})
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.event", name: "first"}))
+	<-firstStarted
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.event", name: "second"}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, dispatcher.Close(ctx), context.DeadlineExceeded)
+	close(releaseFirst)
+
+	select {
+	case <-secondStarted:
+		t.Fatal("queued batch started after close timeout")
+	case <-time.After(30 * time.Millisecond):
+	}
 }

--- a/ddd/event/dispatcher_test.go
+++ b/ddd/event/dispatcher_test.go
@@ -107,3 +107,53 @@ func TestDispatcherCloseDrainsAcceptedBatches(t *testing.T) {
 	wg.Wait()
 	<-done
 }
+
+// Intent: DispatchAll submits one batch, so its events must be processed
+// contiguously without another batch interleaving between them.
+func TestDispatcherDispatchAllBatchDoesNotInterleave(t *testing.T) {
+	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
+	defer dispatcher.Close(context.Background())
+
+	seen := make(chan string, 4)
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.event"},
+		handle: func(_ context.Context, ev event.Event) {
+			seen <- ev.(testEvent).name
+		},
+	})
+
+	require.True(t, dispatcher.DispatchAll([]event.Event{
+		testEvent{kind: "order.event", name: "a1"},
+		testEvent{kind: "order.event", name: "a2"},
+	}))
+	require.True(t, dispatcher.DispatchAll([]event.Event{
+		testEvent{kind: "order.event", name: "b1"},
+		testEvent{kind: "order.event", name: "b2"},
+	}))
+
+	require.Equal(t, "a1", <-seen)
+	require.Equal(t, "a2", <-seen)
+	require.Equal(t, "b1", <-seen)
+	require.Equal(t, "b2", <-seen)
+}
+
+// Intent: handlers for one event run in subscription order, which makes
+// in-process reactions deterministic.
+func TestDispatcherHandlersRunInSubscriptionOrder(t *testing.T) {
+	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
+	defer dispatcher.Close(context.Background())
+
+	seen := make(chan string, 2)
+	dispatcher.Subscribe(handlerFunc{
+		kinds:  []event.Kind{"order.paid"},
+		handle: func(context.Context, event.Event) { seen <- "first" },
+	})
+	dispatcher.Subscribe(handlerFunc{
+		kinds:  []event.Kind{"order.paid"},
+		handle: func(context.Context, event.Event) { seen <- "second" },
+	})
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.Equal(t, "first", <-seen)
+	require.Equal(t, "second", <-seen)
+}

--- a/ddd/event/dispatcher_test.go
+++ b/ddd/event/dispatcher_test.go
@@ -508,11 +508,11 @@ func TestDispatcherCloseInterruptedHookReportsAbandonedWork(t *testing.T) {
 
 	snapshot := receiveWithin(t, "close interrupted hook", interrupted)
 	require.ErrorIs(t, snapshot.Error, context.DeadlineExceeded)
-	require.Equal(t, 1, snapshot.PendingBatchCount)
-	require.Equal(t, 1, snapshot.PendingEventCount)
 	require.Equal(t, uint64(1), snapshot.InFlightBatchID)
-	require.Equal(t, []uint64{2}, snapshot.PendingBatchIDs)
-	require.Equal(t, []event.Kind{"order.event"}, snapshot.PendingEventKinds)
+	require.Len(t, snapshot.PendingBatches, 1)
+	require.Equal(t, uint64(2), snapshot.PendingBatches[0].BatchID)
+	require.Len(t, snapshot.PendingBatches[0].Events, 1)
+	require.Equal(t, "third", snapshot.PendingBatches[0].Events[0].(testEvent).name)
 }
 
 // Intent: after Close times out during process shutdown, queued batches should

--- a/ddd/event/doc.go
+++ b/ddd/event/doc.go
@@ -1,0 +1,11 @@
+// Package event provides domain event primitives for use inside one bounded
+// context.
+//
+// The package is intentionally scoped to in-process domain events. It is not an
+// integration message bus, broker abstraction, transactional outbox, or reliable
+// delivery mechanism across process restarts.
+//
+// Dispatch only reports whether a batch was accepted by the dispatcher. It does
+// not report handler success or failure. Handlers represent follow-up
+// transactions and own their own error policy.
+package event

--- a/ddd/event/event.go
+++ b/ddd/event/event.go
@@ -1,0 +1,33 @@
+package event
+
+import "context"
+
+// Kind identifies the kind of a domain event inside one bounded context.
+type Kind string
+
+// Event is a domain fact raised inside one bounded context.
+type Event interface {
+	Kind() Kind
+}
+
+// Collection stores domain events raised by an aggregate until the application
+// layer drains them after persistence succeeds.
+type Collection interface {
+	Add(Event) bool
+	Drain() []Event
+	Len() int
+}
+
+// Handler reacts to a domain event as a follow-up transaction.
+type Handler interface {
+	Listening() []Kind
+	Handle(context.Context, Event)
+}
+
+// Dispatcher accepts domain event batches for in-process handling.
+type Dispatcher interface {
+	Subscribe(Handler)
+	Dispatch(Event) bool
+	DispatchAll([]Event) bool
+	Close(context.Context) error
+}

--- a/ddd/event/event.go
+++ b/ddd/event/event.go
@@ -10,6 +10,20 @@ type Event interface {
 	Kind() Kind
 }
 
+// UnhandledContext describes an event that has no registered handler.
+type UnhandledContext struct {
+	BatchID uint64
+	Event   Event
+}
+
+// PanicContext describes a recovered handler panic.
+type PanicContext struct {
+	BatchID uint64
+	Event   Event
+	Panic   any
+	Stack   []byte
+}
+
 // Collection stores domain events raised by an aggregate until the application
 // layer drains them after persistence succeeds.
 type Collection interface {

--- a/ddd/event/event.go
+++ b/ddd/event/event.go
@@ -24,6 +24,17 @@ type PanicContext struct {
 	Stack   []byte
 }
 
+// CloseInterruptedContext describes accepted work that was not confirmed as
+// handled before Close was interrupted.
+type CloseInterruptedContext struct {
+	Error             error
+	PendingBatchCount int
+	PendingEventCount int
+	InFlightBatchID   uint64
+	PendingBatchIDs   []uint64
+	PendingEventKinds []Kind
+}
+
 // Collection stores domain events raised by an aggregate until the application
 // layer drains them after persistence succeeds.
 type Collection interface {

--- a/ddd/event/event.go
+++ b/ddd/event/event.go
@@ -24,15 +24,19 @@ type PanicContext struct {
 	Stack   []byte
 }
 
+// PendingBatch describes an accepted event batch that was not started before
+// Close was interrupted.
+type PendingBatch struct {
+	BatchID uint64
+	Events  []Event
+}
+
 // CloseInterruptedContext describes accepted work that was not confirmed as
 // handled before Close was interrupted.
 type CloseInterruptedContext struct {
-	Error             error
-	PendingBatchCount int
-	PendingEventCount int
-	InFlightBatchID   uint64
-	PendingBatchIDs   []uint64
-	PendingEventKinds []Kind
+	Error           error
+	InFlightBatchID uint64
+	PendingBatches  []PendingBatch
 }
 
 // Collection stores domain events raised by an aggregate until the application

--- a/ddd/event/option.go
+++ b/ddd/event/option.go
@@ -57,6 +57,14 @@ func WithPanicHandler(fn func(PanicContext)) Option {
 	}
 }
 
+// WithCloseInterruptedHandler sets a hook for close interruptions that leave
+// accepted work unconfirmed.
+func WithCloseInterruptedHandler(fn func(CloseInterruptedContext)) Option {
+	return func(d *dispatcher) {
+		d.closeInterruptedHandler = fn
+	}
+}
+
 // WithBufferSize sets the maximum number of queued event batches.
 func WithBufferSize(size int) Option {
 	return func(d *dispatcher) {

--- a/ddd/event/option.go
+++ b/ddd/event/option.go
@@ -1,0 +1,67 @@
+package event
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// Option configures a Dispatcher during construction.
+type Option func(*dispatcher)
+
+// WithLogger sets the logger for the dispatcher.
+func WithLogger(logger *slog.Logger) Option {
+	return func(d *dispatcher) {
+		if logger != nil {
+			d.logger = logger
+		}
+	}
+}
+
+// WithDelayClose sets the delay before the dispatcher starts rejecting new events during shutdown.
+func WithDelayClose(delay time.Duration) Option {
+	return func(d *dispatcher) {
+		if delay >= 0 {
+			d.delayClose = delay
+		}
+	}
+}
+
+// WithHandlerTimeout sets the timeout for each handler invocation.
+func WithHandlerTimeout(timeout time.Duration) Option {
+	return func(d *dispatcher) {
+		if timeout >= 0 {
+			d.handlerTimeout = timeout
+		}
+	}
+}
+
+// WithContextFactory sets a function to derive a new context for each event dispatch.
+func WithContextFactory(fn func(context.Context, Event) context.Context) Option {
+	return func(d *dispatcher) {
+		d.contextFactory = fn
+	}
+}
+
+// WithUnhandledEventHandler sets a hook for events with no registered handler.
+func WithUnhandledEventHandler(fn func(Event)) Option {
+	return func(d *dispatcher) {
+		d.unhandledEventHandler = fn
+	}
+}
+
+// WithPanicHandler sets a hook for recovered handler panics.
+func WithPanicHandler(fn func(Event, any, []byte)) Option {
+	return func(d *dispatcher) {
+		d.panicHandler = fn
+	}
+}
+
+// WithBufferSize sets the maximum number of queued event batches.
+func WithBufferSize(size int) Option {
+	return func(d *dispatcher) {
+		if size > 0 {
+			d.bufferSize = size
+		}
+	}
+}

--- a/ddd/event/option.go
+++ b/ddd/event/option.go
@@ -9,7 +9,7 @@ import (
 // Option configures a Dispatcher during construction.
 type Option func(*dispatcher)
 
-// WithLogger sets the logger for the dispatcher.
+// WithLogger sets the logger for dispatcher lifecycle and runtime diagnostics.
 func WithLogger(logger *slog.Logger) Option {
 	return func(d *dispatcher) {
 		if logger != nil {
@@ -44,14 +44,14 @@ func WithContextFactory(fn func(context.Context, Event) context.Context) Option 
 }
 
 // WithUnhandledEventHandler sets a hook for events with no registered handler.
-func WithUnhandledEventHandler(fn func(Event)) Option {
+func WithUnhandledEventHandler(fn func(UnhandledContext)) Option {
 	return func(d *dispatcher) {
 		d.unhandledEventHandler = fn
 	}
 }
 
 // WithPanicHandler sets a hook for recovered handler panics.
-func WithPanicHandler(fn func(Event, any, []byte)) Option {
+func WithPanicHandler(fn func(PanicContext)) Option {
 	return func(d *dispatcher) {
 		d.panicHandler = fn
 	}

--- a/docs/mediator-migration.md
+++ b/docs/mediator-migration.md
@@ -1,0 +1,34 @@
+# Migrating from mediator to ddd/event
+
+The `mediator` package is now legacy. Existing APIs remain source-compatible,
+but new domain event code should use `github.com/go-jimu/components/ddd/event`.
+
+`mediator` will only receive compatibility fixes. New domain-event behavior will
+be added to `ddd/event`.
+
+## Key differences
+
+- `mediator.Dispatch` returns an `error`; `ddd/event.Dispatch` returns `bool`
+  and only reports whether a batch was accepted.
+- `ddd/event.Dispatch` does not accept caller context. Handler context is owned
+  by the dispatcher because event handling is a follow-up transaction.
+- `ddd/event.Handler.Handle` does not return an error. Handlers own their own
+  error policy.
+- `ddd/event.DispatchAll` preserves one aggregate transaction as one batch.
+- `ddd/event.Close` reports shutdown interruption through logs and an optional
+  close-interrupted hook with pending batches.
+- `ddd/event` is only for in-process domain events inside one bounded context.
+  It is not an integration message bus, broker abstraction, outbox, retry
+  system, or reliable delivery mechanism across process restarts.
+
+## Replacement guide
+
+- Replace `mediator.NewEventCollection` with `event.NewCollection`.
+- Replace `mediator.NewInMemMediator` with `event.NewDispatcher`.
+- Replace `mediator.EventKind` with `event.Kind`.
+- Replace `mediator.Event` with `event.Event`.
+- Replace `mediator.EventHandler` with `event.Handler`.
+- Prefer explicit dispatcher instances instead of the global `mediator.Default`.
+
+Keep `mediator` where compatibility matters. Migrate new or actively revised
+domain event code to `ddd/event`.

--- a/docs/project-knowledge/architecture.md
+++ b/docs/project-knowledge/architecture.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-05-10
-updated_by: superpowers-memory:rebuild
-triggered_by_plan: null
+updated_by: superpowers-memory:update
+triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 ---
 
 # Architecture
@@ -13,7 +13,7 @@ small top-level capabilities instead of an application with service entry
 points, deployment manifests, or bounded-context folders.
 
 The current eventbus branch keeps the existing `mediator` package compatible and
-adds a design direction for a new DDD concept namespace under `ddd/`.
+adds a DDD concept namespace under `ddd/`.
 
 ## System Context
 
@@ -28,8 +28,9 @@ adds a design direction for a new DDD concept namespace under `ddd/`.
 - `fsm/` — finite state machine primitives and transition checks. Key abstractions: `State`, `StateContext`, `StateMachine`.
 - `logger/` and `sloghelper/` — logger adapters and helpers for `log/slog`.
 - `mediator/` — existing in-process event mediator with global default, event collection, subscription, dispatch, and graceful shutdown.
+- `ddd/event/` — DDD-oriented domain event collection and in-process batch dispatch. Key abstractions: `Event`, `Collection`, `Dispatcher`, `Handler`.
 - `validation/` — notification and specification validation helpers.
-- `docs/superpowers/specs/` — approved design specs for planned work, including `ddd/event`.
+- `docs/superpowers/specs/` and `docs/superpowers/plans/` — design and implementation records for planned or recently completed work.
 
 There is no application-layer call graph. Consumers compose these packages in
 their own applications.

--- a/docs/project-knowledge/architecture.md
+++ b/docs/project-knowledge/architecture.md
@@ -1,0 +1,90 @@
+---
+last_updated: 2026-05-10
+updated_by: superpowers-memory:rebuild
+triggered_by_plan: null
+---
+
+# Architecture
+
+## Pattern Overview
+
+This repository is a public Go component library. Packages are organized as
+small top-level capabilities instead of an application with service entry
+points, deployment manifests, or bounded-context folders.
+
+The current eventbus branch keeps the existing `mediator` package compatible and
+adds a design direction for a new DDD concept namespace under `ddd/`.
+
+## System Context
+
+- Library consumers import individual packages from `github.com/go-jimu/components`.
+- GitHub Actions runs tests, benchmarks, and coverage on pull requests and master.
+- Codecov receives the generated `coverage.txt` artifact.
+
+## Layering
+
+- `config/` — configuration loading, resolving, merging, watching, and typed value access. Key abstraction: `Config`.
+- `encoding/` — codec registry plus JSON/YAML/TOML/Protobuf codec packages. Key abstraction: `Codec`.
+- `fsm/` — finite state machine primitives and transition checks. Key abstractions: `State`, `StateContext`, `StateMachine`.
+- `logger/` and `sloghelper/` — logger adapters and helpers for `log/slog`.
+- `mediator/` — existing in-process event mediator with global default, event collection, subscription, dispatch, and graceful shutdown.
+- `validation/` — notification and specification validation helpers.
+- `docs/superpowers/specs/` — approved design specs for planned work, including `ddd/event`.
+
+There is no application-layer call graph. Consumers compose these packages in
+their own applications.
+
+## Scenario Sequences
+
+```mermaid
+sequenceDiagram
+    participant App as Consumer application
+    participant Config as config.Config
+    participant Source as config.Source
+    participant Watcher as config.Watcher
+    App->>Config: Load()
+    Config->>Source: Load()
+    Config->>Source: Watch()
+    Source-->>Config: Watcher
+    Watcher-->>Config: next key values
+    Config-->>App: updated Value observers
+```
+
+```mermaid
+sequenceDiagram
+    participant App as Consumer application
+    participant Encoding as encoding registry
+    participant Codec as codec package
+    App->>Codec: blank import package
+    Codec->>Encoding: RegisterCodec(codec)
+    App->>Encoding: GetCodec(name)
+    Encoding-->>App: codec or nil
+```
+
+```mermaid
+sequenceDiagram
+    participant Aggregate as Domain aggregate
+    participant Collection as ddd/event.Collection
+    participant App as Application service
+    participant Dispatcher as ddd/event.Dispatcher
+    Aggregate->>Collection: Add(domain event)
+    App->>App: Save aggregate
+    App->>Collection: Drain()
+    App->>Dispatcher: DispatchAll(events batch)
+    Dispatcher-->>App: accepted bool
+```
+
+## Key Object FSMs
+
+```mermaid
+stateDiagram-v2
+    [*] --> Collecting
+    Collecting --> Drained: Drain emits event batch
+    Drained --> Drained: Drain returns empty
+    Drained --> Drained: Add rejected
+```
+
+## Key Design Decisions
+
+- Preserve existing `mediator` API compatibility; add new DDD event module separately. See `decisions.md`.
+- Place DDD concept packages under `ddd/`, with `ddd/event` first and future `ddd/message` / `ddd/message/outbox` reserved. See `docs/superpowers/specs/2026-05-10-ddd-event-design.md`.

--- a/docs/project-knowledge/conventions.md
+++ b/docs/project-knowledge/conventions.md
@@ -1,0 +1,31 @@
+---
+last_updated: 2026-05-10
+updated_by: superpowers-memory:rebuild
+triggered_by_plan: null
+---
+
+# Conventions
+
+## Package Organization
+
+- Top-level directories are independent reusable Go packages.
+- Keep existing package APIs compatible unless a new package is introduced for a breaking design.
+- New DDD event work belongs under `ddd/event`; do not retrofit the existing `mediator` package.
+
+## Testing
+
+- Use Go tests in the package under test.
+- CI expects race-enabled test runs through `make test`.
+- Benchmark coverage is part of the GitHub Actions workflow through `make benchmark`.
+
+## Event Design
+
+- `mediator` remains the compatibility package for existing users.
+- `ddd/event` should document that it is for domain events inside one bounded context.
+- Domain event handlers in the planned module are follow-up reactions and do not report success back to the previous transaction.
+
+## Git And CI
+
+- Pull requests target `master`.
+- CI runs on pull requests and pushes to `master`.
+- Coverage is published from the Go `1.24.x` matrix job.

--- a/docs/project-knowledge/decisions.md
+++ b/docs/project-knowledge/decisions.md
@@ -1,0 +1,19 @@
+---
+last_updated: 2026-05-10
+updated_by: superpowers-memory:rebuild
+triggered_by_plan: null
+---
+
+# Decisions
+
+## Preserve `mediator` and add `ddd/event` separately
+
+Decision: keep the existing `mediator` API stable and introduce a new DDD-oriented domain event package.
+Trade-off: avoids breaking existing users while accepting two event-related packages with different semantics.
+Pointer: `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
+
+## Use `ddd/` as a DDD concept namespace
+
+Decision: reserve `ddd/event`, future `ddd/message`, and future `ddd/message/outbox`.
+Trade-off: improves naming consistency, but package documentation must clarify that `ddd/` is not an application Domain Layer directory.
+Pointer: `docs/superpowers/specs/2026-05-10-ddd-event-design.md`

--- a/docs/project-knowledge/features.md
+++ b/docs/project-knowledge/features.md
@@ -48,10 +48,10 @@ triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 
 #### Existing in-process mediator
 
-- Enables: consumers subscribe handlers and dispatch events with graceful shutdown behavior.
+- Enables: existing consumers subscribe handlers and dispatch events with graceful shutdown behavior.
 - Actors / Entry Points: consumers use `mediator.NewInMemMediator`, `Dispatch`, `Subscribe`, and `EventCollection`.
-- Capability Boundary: compatibility package; separate from the DDD event module.
-- References: `mediator/`
+- Capability Boundary: legacy compatibility package; new domain event code should use `ddd/event`.
+- References: `mediator/`, `docs/mediator-migration.md`
 
 ### DDD Event
 

--- a/docs/project-knowledge/features.md
+++ b/docs/project-knowledge/features.md
@@ -64,7 +64,7 @@ triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 
 #### Dispatcher runtime diagnostics
 
-- Enables: dispatcher owners trace batch admission, lifecycle, rejected dispatches, unhandled events, nil contexts, and handler panics.
+- Enables: dispatcher owners trace batch admission, lifecycle, shutdown interruptions, rejected dispatches, unhandled events, nil contexts, and handler panics.
 - Actors / Entry Points: application services configure `ddd/event.Dispatcher` options and consume logs or runtime hooks.
 - Capability Boundary: diagnostics for in-process domain event dispatch only; no durable event audit log.
 - References: `ddd/event/`, `docs/superpowers/specs/2026-05-10-ddd-event-design.md`

--- a/docs/project-knowledge/features.md
+++ b/docs/project-knowledge/features.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-05-10
-updated_by: superpowers-memory:rebuild
-triggered_by_plan: null
+updated_by: superpowers-memory:update
+triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 ---
 
 # Features
@@ -50,8 +50,17 @@ triggered_by_plan: null
 
 - Enables: consumers subscribe handlers and dispatch events with graceful shutdown behavior.
 - Actors / Entry Points: consumers use `mediator.NewInMemMediator`, `Dispatch`, `Subscribe`, and `EventCollection`.
-- Capability Boundary: compatibility package; not changed by the planned DDD event module.
+- Capability Boundary: compatibility package; separate from the DDD event module.
 - References: `mediator/`
+
+### DDD Event
+
+#### Domain event collection and in-process dispatch
+
+- Enables: DDD-style services collect domain events inside one bounded context and submit event batches after persistence.
+- Actors / Entry Points: domain aggregates use `ddd/event.Collection`; application services use `ddd/event.Dispatcher`.
+- Capability Boundary: single-process domain events only; no integration message bus, broker, retry, or outbox.
+- References: `ddd/event/`, `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 
 ### Validation
 
@@ -61,14 +70,3 @@ triggered_by_plan: null
 - Actors / Entry Points: consumers import `validation`.
 - Capability Boundary: generic validation helpers; no application validation framework.
 - References: `validation/`
-
-## Planned
-
-### DDD Event
-
-#### Domain event collection and in-process dispatch
-
-- Enables: DDD-style services collect domain events inside one bounded context and submit event batches after persistence.
-- Actors / Entry Points: domain aggregates use `ddd/event.Collection`; application services use `ddd/event.Dispatcher`.
-- Capability Boundary: single-process domain events only; no integration message bus, broker, retry, or outbox.
-- References: `docs/superpowers/specs/2026-05-10-ddd-event-design.md`

--- a/docs/project-knowledge/features.md
+++ b/docs/project-knowledge/features.md
@@ -1,0 +1,74 @@
+---
+last_updated: 2026-05-10
+updated_by: superpowers-memory:rebuild
+triggered_by_plan: null
+---
+
+# Features
+
+## Implemented
+
+### Configuration
+
+#### Config loading and watching
+
+- Enables: consumers combine sources, load values, resolve references, and observe updates.
+- Actors / Entry Points: library consumers call `config.New`, `Load`, `Value`, `Watch`, and `Close`.
+- Capability Boundary: package-level configuration component; not an application configuration service.
+- References: `config/`
+
+### Encoding
+
+#### Codec registry
+
+- Enables: consumers register and retrieve codecs by stable names.
+- Actors / Entry Points: codec packages register themselves; consumers call `encoding.GetCodec`.
+- Capability Boundary: registry and codec abstraction only; transport usage lives in consumers.
+- References: `encoding/`
+
+### State Machines
+
+#### FSM primitives
+
+- Enables: consumers define states, actions, conditions, and transitions.
+- Actors / Entry Points: consumers use `fsm.StateMachine` and related primitives.
+- Capability Boundary: generic state-machine utility; no business aggregate model is included.
+- References: `fsm/`
+
+### Logging
+
+#### Logger helpers
+
+- Enables: consumers attach and derive loggers and attributes with `log/slog`.
+- Actors / Entry Points: library consumers import `logger` and `sloghelper`.
+- Capability Boundary: logging utilities only; no centralized logging backend.
+- References: `logger/`, `sloghelper/`
+
+### Mediator
+
+#### Existing in-process mediator
+
+- Enables: consumers subscribe handlers and dispatch events with graceful shutdown behavior.
+- Actors / Entry Points: consumers use `mediator.NewInMemMediator`, `Dispatch`, `Subscribe`, and `EventCollection`.
+- Capability Boundary: compatibility package; not changed by the planned DDD event module.
+- References: `mediator/`
+
+### Validation
+
+#### Notification and specification helpers
+
+- Enables: consumers collect validation notifications and apply specification-style checks.
+- Actors / Entry Points: consumers import `validation`.
+- Capability Boundary: generic validation helpers; no application validation framework.
+- References: `validation/`
+
+## Planned
+
+### DDD Event
+
+#### Domain event collection and in-process dispatch
+
+- Enables: DDD-style services collect domain events inside one bounded context and submit event batches after persistence.
+- Actors / Entry Points: domain aggregates use `ddd/event.Collection`; application services use `ddd/event.Dispatcher`.
+- Capability Boundary: single-process domain events only; no integration message bus, broker, retry, or outbox.
+- References: `docs/superpowers/specs/2026-05-10-ddd-event-design.md`

--- a/docs/project-knowledge/features.md
+++ b/docs/project-knowledge/features.md
@@ -62,6 +62,13 @@ triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 - Capability Boundary: single-process domain events only; no integration message bus, broker, retry, or outbox.
 - References: `ddd/event/`, `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 
+#### Dispatcher runtime diagnostics
+
+- Enables: dispatcher owners trace batch admission, lifecycle, rejected dispatches, unhandled events, nil contexts, and handler panics.
+- Actors / Entry Points: application services configure `ddd/event.Dispatcher` options and consume logs or runtime hooks.
+- Capability Boundary: diagnostics for in-process domain event dispatch only; no durable event audit log.
+- References: `ddd/event/`, `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
+
 ### Validation
 
 #### Notification and specification helpers

--- a/docs/project-knowledge/features.md
+++ b/docs/project-knowledge/features.md
@@ -64,9 +64,9 @@ triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 
 #### Dispatcher runtime diagnostics
 
-- Enables: dispatcher owners trace batch admission, lifecycle, shutdown interruptions, rejected dispatches, unhandled events, nil contexts, and handler panics.
+- Enables: dispatcher owners trace runtime dispatch health and shutdown interruptions.
 - Actors / Entry Points: application services configure `ddd/event.Dispatcher` options and consume logs or runtime hooks.
-- Capability Boundary: diagnostics for in-process domain event dispatch only; no durable event audit log.
+- Capability Boundary: diagnostics for in-process domain event dispatch only; forced shutdown pending events are best-effort offline compensation clues, not a durable event audit log.
 - References: `ddd/event/`, `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 
 ### Validation

--- a/docs/project-knowledge/glossary.md
+++ b/docs/project-knowledge/glossary.md
@@ -1,0 +1,19 @@
+---
+last_updated: 2026-05-10
+updated_by: superpowers-memory:rebuild
+triggered_by_plan: null
+---
+
+# Glossary
+
+**Mediator** — Existing in-process event dispatch package kept for compatibility. → `mediator/`
+
+**Domain Event** — A fact raised inside one bounded context by domain behavior. → `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
+
+**Event Collection** — A per-aggregate holder for undrained domain events. → `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
+
+**Dispatcher** — Planned in-process batch admission and handler execution component for `ddd/event`. → `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
+
+**Integration Message** — Future cross bounded-context/service contract, separate from domain events. → `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
+
+**Outbox** — Future reliability mechanism for integration messages, not a domain event dispatcher. → `docs/superpowers/specs/2026-05-10-ddd-event-design.md`

--- a/docs/project-knowledge/glossary.md
+++ b/docs/project-knowledge/glossary.md
@@ -14,6 +14,8 @@ triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 
 **Dispatcher** — In-process batch admission and handler execution component for `ddd/event`. → `ddd/event/`
 
+**BatchID** — Dispatcher-local diagnostic identifier assigned to each accepted `ddd/event` batch. → `ddd/event/`
+
 **Integration Message** — Future cross bounded-context/service contract, separate from domain events. → `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 
 **Outbox** — Future reliability mechanism for integration messages, not a domain event dispatcher. → `docs/superpowers/specs/2026-05-10-ddd-event-design.md`

--- a/docs/project-knowledge/glossary.md
+++ b/docs/project-knowledge/glossary.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-05-10
-updated_by: superpowers-memory:rebuild
-triggered_by_plan: null
+updated_by: superpowers-memory:update
+triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 ---
 
 # Glossary
@@ -10,9 +10,9 @@ triggered_by_plan: null
 
 **Domain Event** — A fact raised inside one bounded context by domain behavior. → `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 
-**Event Collection** — A per-aggregate holder for undrained domain events. → `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
+**Event Collection** — A per-aggregate holder for undrained domain events. → `ddd/event/`
 
-**Dispatcher** — Planned in-process batch admission and handler execution component for `ddd/event`. → `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
+**Dispatcher** — In-process batch admission and handler execution component for `ddd/event`. → `ddd/event/`
 
 **Integration Message** — Future cross bounded-context/service contract, separate from domain events. → `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 

--- a/docs/project-knowledge/glossary.md
+++ b/docs/project-knowledge/glossary.md
@@ -16,6 +16,8 @@ triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 
 **BatchID** — Dispatcher-local diagnostic identifier assigned to each accepted `ddd/event` batch. → `ddd/event/`
 
+**Abandoned Batch** — Accepted `ddd/event` batch not confirmed as handled before forced close interruption. → `ddd/event/`
+
 **Integration Message** — Future cross bounded-context/service contract, separate from domain events. → `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 
 **Outbox** — Future reliability mechanism for integration messages, not a domain event dispatcher. → `docs/superpowers/specs/2026-05-10-ddd-event-design.md`

--- a/docs/project-knowledge/glossary.md
+++ b/docs/project-knowledge/glossary.md
@@ -6,7 +6,7 @@ triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 
 # Glossary
 
-**Mediator** — Existing in-process event dispatch package kept for compatibility. → `mediator/`
+**Mediator** — Legacy in-process event dispatch package kept for compatibility. → `mediator/`
 
 **Domain Event** — A fact raised inside one bounded context by domain behavior. → `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 

--- a/docs/project-knowledge/index.md
+++ b/docs/project-knowledge/index.md
@@ -2,14 +2,14 @@
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
 triggered_by_plan: 2026-05-10-ddd-event-implementation.md
-covers_branch: hotfix/eventbus@8f2b393
+covers_branch: hotfix/eventbus@c89065c
 ---
 
 # Project Knowledge Index
 
 - `architecture.md` — top-level Go component layout including the new `ddd/event` DDD concept package.
-- `features.md` — current capabilities including implemented `ddd/event` collection and in-process dispatch.
+- `features.md` — current capabilities including `ddd/event` collection, in-process dispatch, and dispatcher diagnostics.
 - `tech-stack.md` — Go 1.24 module, CI matrix 1.23/1.24/1.25, core dependencies and Make targets.
 - `conventions.md` — package style, tests with `go test -race -covermode=atomic`, CI/benchmark workflow.
 - `decisions.md` — design decision summary for preserving `mediator` and adding `ddd/event`.
-- `glossary.md` — project terms including mediator, domain event, event collection, dispatcher, integration message, and outbox.
+- `glossary.md` — project terms including mediator, domain event, event collection, dispatcher, BatchID, integration message, and outbox.

--- a/docs/project-knowledge/index.md
+++ b/docs/project-knowledge/index.md
@@ -2,7 +2,7 @@
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
 triggered_by_plan: 2026-05-10-ddd-event-implementation.md
-covers_branch: hotfix/eventbus@ca94b34
+covers_branch: hotfix/eventbus@65cc3a2
 ---
 
 # Project Knowledge Index

--- a/docs/project-knowledge/index.md
+++ b/docs/project-knowledge/index.md
@@ -2,14 +2,14 @@
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
 triggered_by_plan: 2026-05-10-ddd-event-implementation.md
-covers_branch: hotfix/eventbus@c89065c
+covers_branch: hotfix/eventbus@ca94b34
 ---
 
 # Project Knowledge Index
 
 - `architecture.md` — top-level Go component layout including the new `ddd/event` DDD concept package.
-- `features.md` — current capabilities including `ddd/event` collection, in-process dispatch, and dispatcher diagnostics.
+- `features.md` — current capabilities including `ddd/event` collection, in-process dispatch, and shutdown-aware diagnostics.
 - `tech-stack.md` — Go 1.24 module, CI matrix 1.23/1.24/1.25, core dependencies and Make targets.
 - `conventions.md` — package style, tests with `go test -race -covermode=atomic`, CI/benchmark workflow.
 - `decisions.md` — design decision summary for preserving `mediator` and adding `ddd/event`.
-- `glossary.md` — project terms including mediator, domain event, event collection, dispatcher, BatchID, integration message, and outbox.
+- `glossary.md` — project terms including mediator, domain event, event collection, dispatcher, BatchID, abandoned batch, integration message, and outbox.

--- a/docs/project-knowledge/index.md
+++ b/docs/project-knowledge/index.md
@@ -1,0 +1,15 @@
+---
+last_updated: 2026-05-10
+updated_by: superpowers-memory:rebuild
+triggered_by_plan: null
+covers_branch: hotfix/eventbus@00010ce
+---
+
+# Project Knowledge Index
+
+- `architecture.md` — top-level Go component layout; config/encoding/fsm/logger/mediator/validation responsibilities; current DDD event design direction.
+- `features.md` — current capabilities and planned `ddd/event` capability from the approved spec.
+- `tech-stack.md` — Go 1.24 module, CI matrix 1.23/1.24/1.25, core dependencies and Make targets.
+- `conventions.md` — package style, tests with `go test -race -covermode=atomic`, CI/benchmark workflow.
+- `decisions.md` — design decision summary for preserving `mediator` and adding `ddd/event`.
+- `glossary.md` — project terms including mediator, domain event, collection, dispatcher, integration message, and outbox.

--- a/docs/project-knowledge/index.md
+++ b/docs/project-knowledge/index.md
@@ -1,15 +1,15 @@
 ---
 last_updated: 2026-05-10
-updated_by: superpowers-memory:rebuild
-triggered_by_plan: null
-covers_branch: hotfix/eventbus@00010ce
+updated_by: superpowers-memory:update
+triggered_by_plan: 2026-05-10-ddd-event-implementation.md
+covers_branch: hotfix/eventbus@8f2b393
 ---
 
 # Project Knowledge Index
 
-- `architecture.md` — top-level Go component layout; config/encoding/fsm/logger/mediator/validation responsibilities; current DDD event design direction.
-- `features.md` — current capabilities and planned `ddd/event` capability from the approved spec.
+- `architecture.md` — top-level Go component layout including the new `ddd/event` DDD concept package.
+- `features.md` — current capabilities including implemented `ddd/event` collection and in-process dispatch.
 - `tech-stack.md` — Go 1.24 module, CI matrix 1.23/1.24/1.25, core dependencies and Make targets.
 - `conventions.md` — package style, tests with `go test -race -covermode=atomic`, CI/benchmark workflow.
 - `decisions.md` — design decision summary for preserving `mediator` and adding `ddd/event`.
-- `glossary.md` — project terms including mediator, domain event, collection, dispatcher, integration message, and outbox.
+- `glossary.md` — project terms including mediator, domain event, event collection, dispatcher, integration message, and outbox.

--- a/docs/project-knowledge/index.md
+++ b/docs/project-knowledge/index.md
@@ -2,14 +2,14 @@
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
 triggered_by_plan: 2026-05-10-ddd-event-implementation.md
-covers_branch: hotfix/eventbus@65cc3a2
+covers_branch: hotfix/eventbus@2232cc0
 ---
 
 # Project Knowledge Index
 
 - `architecture.md` — top-level Go component layout including the new `ddd/event` DDD concept package.
-- `features.md` — current capabilities including `ddd/event` collection, in-process dispatch, and shutdown-aware diagnostics.
+- `features.md` — current capabilities including legacy `mediator`, `ddd/event` collection, in-process dispatch, and diagnostics.
 - `tech-stack.md` — Go 1.24 module, CI matrix 1.23/1.24/1.25, core dependencies and Make targets.
 - `conventions.md` — package style, tests with `go test -race -covermode=atomic`, CI/benchmark workflow.
 - `decisions.md` — design decision summary for preserving `mediator` and adding `ddd/event`.
-- `glossary.md` — project terms including mediator, domain event, event collection, dispatcher, BatchID, abandoned batch, integration message, and outbox.
+- `glossary.md` — project terms including legacy mediator, domain event, event collection, dispatcher, BatchID, abandoned batch, integration message, and outbox.

--- a/docs/project-knowledge/tech-stack.md
+++ b/docs/project-knowledge/tech-stack.md
@@ -1,0 +1,28 @@
+---
+last_updated: 2026-05-10
+updated_by: superpowers-memory:rebuild
+triggered_by_plan: null
+---
+
+# Tech Stack
+
+## Language And Module
+
+- Go module: `github.com/go-jimu/components`
+- Declared Go version: `1.24.0`
+- CI test matrix: Go `1.23.x`, `1.24.x`, and `1.25.x`
+
+## Key Dependencies
+
+- `log/slog` from the standard library is the logging baseline.
+- `github.com/samber/oops` is used for error wrapping in some packages.
+- `google.golang.org/protobuf` supports the Protobuf codec package.
+- `dario.cat/mergo`, `gopkg.in/yaml.v3`, and `github.com/pelletier/go-toml/v2` support configuration and encoding behavior.
+- `github.com/stretchr/testify` is used in tests.
+
+## Build And CI
+
+- `make test` runs `go test -race -covermode=atomic -v -coverprofile=coverage.txt ./...`.
+- `make benchmark` runs package benchmarks.
+- GitHub Actions runs unit tests, benchmarks, coverage artifact upload, and Codecov reporting.
+- The `auto-tag` workflow path bumps tags on merges into `master`.

--- a/docs/superpowers/plans/2026-05-10-ddd-event-implementation.md
+++ b/docs/superpowers/plans/2026-05-10-ddd-event-implementation.md
@@ -1,0 +1,1058 @@
+# DDD Event Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `github.com/go-jimu/components/ddd/event`, a DDD-oriented in-process domain event collection and dispatch package.
+
+**Architecture:** Keep the existing `mediator` package untouched. Add `ddd/event` as a new package with collection primitives for aggregates and an asynchronous single-worker dispatcher whose queue unit is an event batch. Dispatch reports only admission acceptance, while handlers represent follow-up transactions and own their own error policy.
+
+**Tech Stack:** Go 1.24 module, standard library `context`, `sync`, `time`, `log/slog`, package tests with `testing` and `stretchr/testify`.
+
+---
+
+## References
+
+- Spec: `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
+- Project knowledge: `docs/project-knowledge/architecture.md`, `docs/project-knowledge/conventions.md`
+- Existing runtime reference: `mediator/option.go`, `mediator/mediator.go`
+
+## Architecture Gate
+
+- Gate level: Level 3, new DDD concept package and dispatch boundary.
+- Bounded context / business capability: reusable component library capability for single-BC domain events.
+- Stable language / data authority: `event.Event` is a domain fact; `event.Collection` is the aggregate-side event buffer; `event.Dispatcher` accepts in-process batches.
+- Affected aggregate, policy, or service: no business aggregate. New shared package API and runtime policy.
+- Invariants and rules: domain collects events only; application drains after persistence; handlers are follow-up transactions; dispatch return value does not report handler success.
+- Technical capability classification: collection is Domain-facing; dispatcher is application/runtime orchestration; queueing, timeout, panic recovery, logging, close behavior are infrastructure runtime mechanics.
+- Layer ownership: domain code owns event definitions; application owns save/drain/dispatch timing; dispatcher owns processing lifecycle.
+- Proceed / Stop: proceed only inside new `ddd/` files and tests; do not modify `mediator`.
+
+## File Structure
+
+- Create `ddd/doc.go`: package-level namespace documentation that `ddd/` is a concept namespace, not an application Domain Layer.
+- Create `ddd/event/doc.go`: package documentation with scope and non-goals.
+- Create `ddd/event/event.go`: public interfaces and type aliases.
+- Create `ddd/event/collection.go`: collection implementation.
+- Create `ddd/event/collection_test.go`: behavior tests for collection lifecycle.
+- Create `ddd/event/option.go`: dispatcher options.
+- Create `ddd/event/dispatcher.go`: dispatcher implementation.
+- Create `ddd/event/dispatcher_test.go`: admission, ordering, runtime, and close behavior tests.
+
+## Test List
+
+Intent source: approved spec `2026-05-10-ddd-event-design.md`.
+
+- [ ] unit real: collection accepts events before drain -> `Add` returns true, `Len` increases, `Drain` returns add order
+- [ ] unit real: collection rejects after drain -> `Add` returns false and repeated `Drain` has length zero
+- [ ] unit real: dispatcher accepts single event while open -> `Dispatch` returns true and handler observes the event
+- [ ] unit real: dispatcher accepts one batch while open -> `DispatchAll` returns true and handler observes events in batch order
+- [ ] unit real: empty batch -> `DispatchAll(nil)` and `DispatchAll([]Event{})` return true and do not call handlers
+- [ ] unit real: close admission boundary -> dispatch after close returns false
+- [ ] unit real: batch FIFO and no interleaving -> a `DispatchAll(A1,A2)` batch is processed contiguously before a later batch
+- [ ] unit real: event handler order -> handlers for the same event run in subscription order
+- [ ] unit real: unhandled event hook -> no subscribed handlers calls configured unhandled hook
+- [ ] unit real: panic recovery -> panic in one handler is recovered and later handlers/events still run
+- [ ] unit real: context factory and timeout -> handler receives dispatcher-owned context with configured values and timeout
+- [ ] unit real: close drains accepted batches -> `Close(ctx)` waits for already accepted work
+- [ ] unit real: close timeout -> `Close(ctx)` returns `ctx.Err()` when accepted work does not finish in time
+
+All tests are `real`: they exercise the real package implementation without mocking the unit under test.
+
+## Task 1: Package Docs And Public API
+
+**Files:**
+- Create: `ddd/doc.go`
+- Create: `ddd/event/doc.go`
+- Create: `ddd/event/event.go`
+
+- [ ] **Step 1: Write package docs and interfaces**
+
+Create `ddd/doc.go`:
+
+```go
+// Package ddd contains reusable components named after DDD concepts.
+//
+// The ddd directory is a component namespace, not a prescription for an
+// application's Domain Layer directory structure.
+package ddd
+```
+
+Create `ddd/event/doc.go`:
+
+```go
+// Package event provides domain event primitives for use inside one bounded
+// context.
+//
+// The package is intentionally scoped to in-process domain events. It is not an
+// integration message bus, broker abstraction, transactional outbox, or reliable
+// delivery mechanism across process restarts.
+//
+// Dispatch only reports whether a batch was accepted by the dispatcher. It does
+// not report handler success or failure. Handlers represent follow-up
+// transactions and own their own error policy.
+package event
+```
+
+Create `ddd/event/event.go`:
+
+```go
+package event
+
+import "context"
+
+// Kind identifies the kind of a domain event inside one bounded context.
+type Kind string
+
+// Event is a domain fact raised inside one bounded context.
+type Event interface {
+	Kind() Kind
+}
+
+// Collection stores domain events raised by an aggregate until the application
+// layer drains them after persistence succeeds.
+type Collection interface {
+	Add(Event) bool
+	Drain() []Event
+	Len() int
+}
+
+// Handler reacts to a domain event as a follow-up transaction.
+type Handler interface {
+	Listening() []Kind
+	Handle(context.Context, Event)
+}
+
+// Dispatcher accepts domain event batches for in-process handling.
+type Dispatcher interface {
+	Subscribe(Handler)
+	Dispatch(Event) bool
+	DispatchAll([]Event) bool
+	Close(context.Context) error
+}
+```
+
+- [ ] **Step 2: Run compile check**
+
+Run:
+
+```bash
+go test ./ddd/event
+```
+
+Expected: PASS with no test files.
+
+- [ ] **Step 3: Commit API skeleton**
+
+```bash
+git add ddd/doc.go ddd/event/doc.go ddd/event/event.go
+git commit -m "feat: add ddd event public api"
+```
+
+## Task 2: Collection Lifecycle
+
+**Files:**
+- Create: `ddd/event/collection_test.go`
+- Create: `ddd/event/collection.go`
+
+- [ ] **Step 1: Write failing collection tests**
+
+Create `ddd/event/collection_test.go`:
+
+```go
+package event_test
+
+import (
+	"testing"
+
+	"github.com/go-jimu/components/ddd/event"
+	"github.com/stretchr/testify/require"
+)
+
+type testEvent struct {
+	kind event.Kind
+	name string
+}
+
+func (e testEvent) Kind() event.Kind { return e.kind }
+
+// Intent: a collection should preserve aggregate-raised event order until the
+// application drains it after persistence.
+func TestCollectionAddDrainOrderAndLen(t *testing.T) {
+	collection := event.NewCollection()
+
+	require.True(t, collection.Add(testEvent{kind: "order.paid", name: "first"}))
+	require.True(t, collection.Add(testEvent{kind: "order.confirmed", name: "second"}))
+	require.Equal(t, 2, collection.Len())
+
+	drained := collection.Drain()
+
+	require.Len(t, drained, 2)
+	require.Equal(t, "first", drained[0].(testEvent).name)
+	require.Equal(t, "second", drained[1].(testEvent).name)
+	require.Equal(t, 0, collection.Len())
+}
+
+// Intent: a drained collection is closed so the same aggregate event batch
+// cannot be appended to or dispatched twice.
+func TestCollectionRejectsAddAfterDrain(t *testing.T) {
+	collection := event.NewCollection()
+	require.True(t, collection.Add(testEvent{kind: "order.paid"}))
+
+	require.Len(t, collection.Drain(), 1)
+	require.False(t, collection.Add(testEvent{kind: "order.confirmed"}))
+	require.Empty(t, collection.Drain())
+	require.Equal(t, 0, collection.Len())
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+go test ./ddd/event -run 'TestCollection' -count=1
+```
+
+Expected: FAIL because `NewCollection` is undefined.
+
+- [ ] **Step 3: Implement collection**
+
+Create `ddd/event/collection.go`:
+
+```go
+package event
+
+type collection struct {
+	events  []Event
+	drained bool
+}
+
+// NewCollection creates an empty aggregate event collection.
+func NewCollection() Collection {
+	return &collection{}
+}
+
+func (c *collection) Add(event Event) bool {
+	if c.drained {
+		return false
+	}
+	c.events = append(c.events, event)
+	return true
+}
+
+func (c *collection) Drain() []Event {
+	if c.drained {
+		return nil
+	}
+	c.drained = true
+	events := c.events
+	c.events = nil
+	return events
+}
+
+func (c *collection) Len() int {
+	if c.drained {
+		return 0
+	}
+	return len(c.events)
+}
+```
+
+- [ ] **Step 4: Run collection tests**
+
+Run:
+
+```bash
+go test ./ddd/event -run 'TestCollection' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit collection**
+
+```bash
+git add ddd/event/collection.go ddd/event/collection_test.go
+git commit -m "feat: add ddd event collection"
+```
+
+## Task 3: Dispatcher Admission And Close
+
+**Files:**
+- Create: `ddd/event/option.go`
+- Create: `ddd/event/dispatcher.go`
+- Modify: `ddd/event/dispatcher_test.go`
+
+- [ ] **Step 1: Write failing admission tests**
+
+Create `ddd/event/dispatcher_test.go`:
+
+```go
+package event_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-jimu/components/ddd/event"
+	"github.com/stretchr/testify/require"
+)
+
+type handlerFunc struct {
+	kinds  []event.Kind
+	handle func(context.Context, event.Event)
+}
+
+func (h handlerFunc) Listening() []event.Kind { return h.kinds }
+func (h handlerFunc) Handle(ctx context.Context, ev event.Event) {
+	if h.handle != nil {
+		h.handle(ctx, ev)
+	}
+}
+
+// Intent: dispatch reports admission acceptance, not handler success.
+func TestDispatcherDispatchAcceptedWhileOpen(t *testing.T) {
+	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
+	defer dispatcher.Close(context.Background())
+
+	called := make(chan event.Event, 1)
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.paid"},
+		handle: func(_ context.Context, ev event.Event) {
+			called <- ev
+		},
+	})
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.Equal(t, event.Kind("order.paid"), (<-called).Kind())
+}
+
+// Intent: empty batches have no domain facts to process and should be accepted
+// without waking handlers.
+func TestDispatcherDispatchAllEmptyBatchAccepted(t *testing.T) {
+	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
+	defer dispatcher.Close(context.Background())
+
+	require.True(t, dispatcher.DispatchAll(nil))
+	require.True(t, dispatcher.DispatchAll([]event.Event{}))
+}
+
+// Intent: once the dispatcher is closed, new event batches are rejected with
+// false instead of reporting handler errors.
+func TestDispatcherRejectsAfterClose(t *testing.T) {
+	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
+	require.NoError(t, dispatcher.Close(context.Background()))
+
+	require.False(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.False(t, dispatcher.DispatchAll([]event.Event{testEvent{kind: "order.paid"}}))
+}
+
+// Intent: close waits for already accepted work to finish before returning.
+func TestDispatcherCloseDrainsAcceptedBatches(t *testing.T) {
+	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	done := make(chan struct{})
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.paid"},
+		handle: func(context.Context, event.Event) {
+			close(started)
+			<-release
+			close(done)
+		},
+	})
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	<-started
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		require.NoError(t, dispatcher.Close(context.Background()))
+	}()
+
+	select {
+	case <-done:
+		t.Fatal("handler finished before release")
+	case <-time.After(20 * time.Millisecond):
+	}
+
+	close(release)
+	wg.Wait()
+	<-done
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+go test ./ddd/event -run 'TestDispatcher' -count=1
+```
+
+Expected: FAIL because dispatcher constructor and options are undefined.
+
+- [ ] **Step 3: Implement options**
+
+Create `ddd/event/option.go`:
+
+```go
+package event
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// Option configures the default in-process dispatcher.
+type Option func(*dispatcher)
+
+// WithLogger sets the logger used for runtime errors such as handler panic.
+func WithLogger(logger *slog.Logger) Option {
+	return func(d *dispatcher) {
+		if logger != nil {
+			d.logger = logger
+		}
+	}
+}
+
+// WithDelayClose sets how long Close waits before rejecting new batches.
+func WithDelayClose(delay time.Duration) Option {
+	return func(d *dispatcher) {
+		if delay >= 0 {
+			d.delayClose = delay
+		}
+	}
+}
+
+// WithHandlerTimeout sets a timeout for each handler invocation.
+func WithHandlerTimeout(timeout time.Duration) Option {
+	return func(d *dispatcher) {
+		if timeout >= 0 {
+			d.handlerTimeout = timeout
+		}
+	}
+}
+
+// WithContextFactory derives the context passed to a handler.
+func WithContextFactory(fn func(context.Context, Event) context.Context) Option {
+	return func(d *dispatcher) {
+		d.contextFactory = fn
+	}
+}
+
+// WithUnhandledEventHandler observes events that have no subscribed handlers.
+func WithUnhandledEventHandler(fn func(Event)) Option {
+	return func(d *dispatcher) {
+		d.unhandledEventHandler = fn
+	}
+}
+
+// WithPanicHandler observes handler panics after the dispatcher recovers them.
+func WithPanicHandler(fn func(Event, any, []byte)) Option {
+	return func(d *dispatcher) {
+		d.panicHandler = fn
+	}
+}
+
+// WithBufferSize sets the number of accepted batches that can wait in memory.
+func WithBufferSize(size int) Option {
+	return func(d *dispatcher) {
+		if size > 0 {
+			d.bufferSize = size
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Implement dispatcher admission, queue, and close**
+
+Create `ddd/event/dispatcher.go`:
+
+```go
+package event
+
+import (
+	"context"
+	"log/slog"
+	"runtime/debug"
+	"sync"
+	"time"
+)
+
+const (
+	defaultBufferSize = 1024
+	defaultDelayClose = 5 * time.Second
+)
+
+type batch struct {
+	events []Event
+}
+
+type dispatcher struct {
+	mu                    sync.Mutex
+	notEmpty              *sync.Cond
+	notFull               *sync.Cond
+	queue                 []batch
+	closed                bool
+	done                  chan struct{}
+	handlers              map[Kind][]Handler
+	logger                *slog.Logger
+	delayClose            time.Duration
+	handlerTimeout        time.Duration
+	contextFactory        func(context.Context, Event) context.Context
+	unhandledEventHandler func(Event)
+	panicHandler          func(Event, any, []byte)
+	bufferSize            int
+	rootCtx               context.Context
+	rootCancel            context.CancelFunc
+}
+
+// NewDispatcher creates an in-process domain event dispatcher.
+func NewDispatcher(opts ...Option) Dispatcher {
+	rootCtx, rootCancel := context.WithCancel(context.Background())
+	d := &dispatcher{
+		done:       make(chan struct{}),
+		handlers:   make(map[Kind][]Handler),
+		logger:     slog.Default(),
+		delayClose: defaultDelayClose,
+		bufferSize: defaultBufferSize,
+		rootCtx:    rootCtx,
+		rootCancel: rootCancel,
+	}
+	d.notEmpty = sync.NewCond(&d.mu)
+	d.notFull = sync.NewCond(&d.mu)
+	for _, opt := range opts {
+		opt(d)
+	}
+	go d.run()
+	return d
+}
+
+func (d *dispatcher) Subscribe(handler Handler) {
+	if handler == nil {
+		return
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return
+	}
+	for _, kind := range handler.Listening() {
+		d.handlers[kind] = append(d.handlers[kind], handler)
+	}
+}
+
+func (d *dispatcher) Dispatch(event Event) bool {
+	if event == nil {
+		return true
+	}
+	return d.DispatchAll([]Event{event})
+}
+
+func (d *dispatcher) DispatchAll(events []Event) bool {
+	if len(events) == 0 {
+		return true
+	}
+	accepted := append([]Event(nil), events...)
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for !d.closed && len(d.queue) >= d.bufferSize {
+		d.notFull.Wait()
+	}
+	if d.closed {
+		return false
+	}
+	d.queue = append(d.queue, batch{events: accepted})
+	d.notEmpty.Signal()
+	return true
+}
+
+func (d *dispatcher) Close(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if d.delayClose > 0 {
+		timer := time.NewTimer(d.delayClose)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			if !timer.Stop() {
+				<-timer.C
+			}
+			d.beginClose()
+			d.rootCancel()
+			return ctx.Err()
+		}
+	}
+	d.beginClose()
+	select {
+	case <-d.done:
+		d.rootCancel()
+		return nil
+	case <-ctx.Done():
+		d.rootCancel()
+		return ctx.Err()
+	}
+}
+
+func (d *dispatcher) beginClose() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.closed {
+		return
+	}
+	d.closed = true
+	d.notEmpty.Broadcast()
+	d.notFull.Broadcast()
+}
+
+func (d *dispatcher) run() {
+	defer close(d.done)
+	for {
+		b, ok := d.nextBatch()
+		if !ok {
+			return
+		}
+		d.handleBatch(b)
+	}
+}
+
+func (d *dispatcher) nextBatch() (batch, bool) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for len(d.queue) == 0 && !d.closed {
+		d.notEmpty.Wait()
+	}
+	if len(d.queue) == 0 && d.closed {
+		return batch{}, false
+	}
+	b := d.queue[0]
+	copy(d.queue, d.queue[1:])
+	d.queue[len(d.queue)-1] = batch{}
+	d.queue = d.queue[:len(d.queue)-1]
+	d.notFull.Signal()
+	return b, true
+}
+
+func (d *dispatcher) handleBatch(b batch) {
+	for _, event := range b.events {
+		d.handleEvent(event)
+	}
+}
+
+func (d *dispatcher) handleEvent(event Event) {
+	handlers := d.handlersFor(event.Kind())
+	if len(handlers) == 0 {
+		if d.unhandledEventHandler != nil {
+			d.unhandledEventHandler(event)
+		}
+		return
+	}
+	for _, handler := range handlers {
+		d.handleOne(handler, event)
+	}
+}
+
+func (d *dispatcher) handlersFor(kind Kind) []Handler {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return append([]Handler(nil), d.handlers[kind]...)
+}
+
+func (d *dispatcher) handleOne(handler Handler, event Event) {
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			stack := debug.Stack()
+			if d.panicHandler != nil {
+				d.panicHandler(event, recovered, stack)
+				return
+			}
+			d.logger.Error("panic occurred while handling domain event",
+				slog.Any("event", event),
+				slog.Any("panic", recovered),
+				slog.String("stack_trace", string(stack)))
+		}
+	}()
+	ctx := d.rootCtx
+	var cancel context.CancelFunc
+	if d.handlerTimeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, d.handlerTimeout)
+	} else {
+		ctx, cancel = context.WithCancel(ctx)
+	}
+	defer cancel()
+	if d.contextFactory != nil {
+		ctx = d.contextFactory(ctx, event)
+	}
+	handler.Handle(ctx, event)
+}
+```
+
+- [ ] **Step 5: Run admission tests**
+
+Run:
+
+```bash
+go test ./ddd/event -run 'TestDispatcher(DispatchAccepted|DispatchAllEmpty|RejectsAfterClose|CloseDrains)' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit dispatcher admission**
+
+```bash
+git add ddd/event/option.go ddd/event/dispatcher.go ddd/event/dispatcher_test.go
+git commit -m "feat: add ddd event dispatcher admission"
+```
+
+## Task 4: Dispatcher Ordering
+
+**Files:**
+- Modify: `ddd/event/dispatcher_test.go`
+- Modify if needed: `ddd/event/dispatcher.go`
+
+- [ ] **Step 1: Add ordering tests**
+
+Append to `ddd/event/dispatcher_test.go`:
+
+```go
+// Intent: DispatchAll submits one batch, so its events must be processed
+// contiguously without another batch interleaving between them.
+func TestDispatcherDispatchAllBatchDoesNotInterleave(t *testing.T) {
+	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
+	defer dispatcher.Close(context.Background())
+
+	seen := make(chan string, 4)
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.event"},
+		handle: func(_ context.Context, ev event.Event) {
+			seen <- ev.(testEvent).name
+		},
+	})
+
+	require.True(t, dispatcher.DispatchAll([]event.Event{
+		testEvent{kind: "order.event", name: "a1"},
+		testEvent{kind: "order.event", name: "a2"},
+	}))
+	require.True(t, dispatcher.DispatchAll([]event.Event{
+		testEvent{kind: "order.event", name: "b1"},
+		testEvent{kind: "order.event", name: "b2"},
+	}))
+
+	require.Equal(t, "a1", <-seen)
+	require.Equal(t, "a2", <-seen)
+	require.Equal(t, "b1", <-seen)
+	require.Equal(t, "b2", <-seen)
+}
+
+// Intent: handlers for one event run in subscription order, which makes
+// in-process reactions deterministic.
+func TestDispatcherHandlersRunInSubscriptionOrder(t *testing.T) {
+	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
+	defer dispatcher.Close(context.Background())
+
+	seen := make(chan string, 2)
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.paid"},
+		handle: func(context.Context, event.Event) { seen <- "first" },
+	})
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.paid"},
+		handle: func(context.Context, event.Event) { seen <- "second" },
+	})
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.Equal(t, "first", <-seen)
+	require.Equal(t, "second", <-seen)
+}
+```
+
+- [ ] **Step 2: Run ordering tests**
+
+Run:
+
+```bash
+go test ./ddd/event -run 'TestDispatcher(DispatchAllBatchDoesNotInterleave|HandlersRunInSubscriptionOrder)' -count=1
+```
+
+Expected: PASS. If a test flakes, inspect `dispatcher.run`, `nextBatch`, and handler snapshotting; do not weaken the tests.
+
+- [ ] **Step 3: Commit ordering coverage**
+
+```bash
+git add ddd/event/dispatcher.go ddd/event/dispatcher_test.go
+git commit -m "test: cover ddd event dispatcher ordering"
+```
+
+## Task 5: Runtime Hooks, Context, Panic, And Timeout
+
+**Files:**
+- Modify: `ddd/event/dispatcher_test.go`
+- Modify if needed: `ddd/event/dispatcher.go`, `ddd/event/option.go`
+
+- [ ] **Step 1: Add runtime behavior tests**
+
+Append to `ddd/event/dispatcher_test.go`:
+
+```go
+// Intent: no-handler events are allowed, but applications can observe them
+// through an explicit hook when useful.
+func TestDispatcherUnhandledEventHook(t *testing.T) {
+	unhandled := make(chan event.Event, 1)
+	dispatcher := event.NewDispatcher(
+		event.WithDelayClose(0),
+		event.WithUnhandledEventHandler(func(ev event.Event) {
+			unhandled <- ev
+		}),
+	)
+	defer dispatcher.Close(context.Background())
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "unknown"}))
+	require.Equal(t, event.Kind("unknown"), (<-unhandled).Kind())
+}
+
+// Intent: a panic in one handler must not stop later handlers or later events
+// in the same accepted batch.
+func TestDispatcherRecoversPanicAndContinues(t *testing.T) {
+	panicked := make(chan any, 1)
+	seen := make(chan string, 2)
+	dispatcher := event.NewDispatcher(
+		event.WithDelayClose(0),
+		event.WithPanicHandler(func(_ event.Event, recovered any, _ []byte) {
+			panicked <- recovered
+		}),
+	)
+	defer dispatcher.Close(context.Background())
+
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.event"},
+		handle: func(context.Context, event.Event) {
+			panic("handler failed")
+		},
+	})
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.event"},
+		handle: func(_ context.Context, ev event.Event) {
+			seen <- ev.(testEvent).name
+		},
+	})
+
+	require.True(t, dispatcher.DispatchAll([]event.Event{
+		testEvent{kind: "order.event", name: "first"},
+		testEvent{kind: "order.event", name: "second"},
+	}))
+	require.Equal(t, "handler failed", <-panicked)
+	require.Equal(t, "first", <-seen)
+	require.Equal(t, "handler failed", <-panicked)
+	require.Equal(t, "second", <-seen)
+}
+
+type contextKey string
+
+// Intent: handler context is owned by the dispatcher, so configured context
+// values should be available without passing caller request context to Dispatch.
+func TestDispatcherContextFactory(t *testing.T) {
+	valueCh := make(chan string, 1)
+	dispatcher := event.NewDispatcher(
+		event.WithDelayClose(0),
+		event.WithContextFactory(func(ctx context.Context, _ event.Event) context.Context {
+			return context.WithValue(ctx, contextKey("trace"), "dispatcher-context")
+		}),
+	)
+	defer dispatcher.Close(context.Background())
+
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.paid"},
+		handle: func(ctx context.Context, _ event.Event) {
+			valueCh <- ctx.Value(contextKey("trace")).(string)
+		},
+	})
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.Equal(t, "dispatcher-context", <-valueCh)
+}
+
+// Intent: configured handler timeout should cancel long-running handler
+// contexts independently of the caller request lifecycle.
+func TestDispatcherHandlerTimeout(t *testing.T) {
+	done := make(chan error, 1)
+	dispatcher := event.NewDispatcher(
+		event.WithDelayClose(0),
+		event.WithHandlerTimeout(10*time.Millisecond),
+	)
+	defer dispatcher.Close(context.Background())
+
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.paid"},
+		handle: func(ctx context.Context, _ event.Event) {
+			<-ctx.Done()
+			done <- ctx.Err()
+		},
+	})
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.ErrorIs(t, <-done, context.DeadlineExceeded)
+}
+
+// Intent: Close should return the caller's timeout when accepted work does not
+// finish within the close deadline.
+func TestDispatcherCloseReturnsContextErrorOnTimeout(t *testing.T) {
+	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
+	block := make(chan struct{})
+	dispatcher.Subscribe(handlerFunc{
+		kinds: []event.Kind{"order.paid"},
+		handle: func(context.Context, event.Event) {
+			<-block
+		},
+	})
+
+	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	require.ErrorIs(t, dispatcher.Close(ctx), context.DeadlineExceeded)
+	close(block)
+}
+```
+
+- [ ] **Step 2: Run runtime tests**
+
+Run:
+
+```bash
+go test ./ddd/event -run 'TestDispatcher(Unhandled|Recovers|ContextFactory|HandlerTimeout|CloseReturns)' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run all ddd/event tests with race detector**
+
+Run:
+
+```bash
+go test -race ./ddd/event
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit runtime behavior**
+
+```bash
+git add ddd/event/dispatcher.go ddd/event/dispatcher_test.go ddd/event/option.go
+git commit -m "feat: add ddd event dispatcher runtime hooks"
+```
+
+## Task 6: Documentation Polish And Full Verification
+
+**Files:**
+- Modify if needed: `ddd/event/doc.go`
+- Modify if needed: `ddd/doc.go`
+- Modify if needed: `docs/project-knowledge/features.md`
+- Modify if needed: `docs/project-knowledge/architecture.md`
+
+- [ ] **Step 1: Run gofmt**
+
+Run:
+
+```bash
+gofmt -w ddd/doc.go ddd/event/*.go
+```
+
+Expected: command exits successfully.
+
+- [ ] **Step 2: Run package tests**
+
+Run:
+
+```bash
+go test -race -covermode=atomic -coverprofile=/tmp/ddd-event-coverage.txt ./ddd/event
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run repository tests**
+
+Run:
+
+```bash
+go test -race -covermode=atomic -v -coverprofile=coverage.txt ./...
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect public documentation**
+
+Run:
+
+```bash
+go doc ./ddd/event
+```
+
+Expected output includes these statements in package documentation:
+
+```text
+domain event primitives for use inside one bounded context
+not an integration message bus
+does not report handler success or failure
+```
+
+- [ ] **Step 5: Update project knowledge if implementation differs from the plan**
+
+If implementation changed any planned package boundary or public behavior, update only the relevant KB lines in:
+
+```text
+docs/project-knowledge/architecture.md
+docs/project-knowledge/features.md
+docs/project-knowledge/glossary.md
+```
+
+Expected: no update is needed if the implementation matches this plan.
+
+- [ ] **Step 6: Final status check**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: only files from this task are modified or untracked.
+
+- [ ] **Step 7: Commit verification/docs**
+
+If Step 5 changed docs, include them. Otherwise commit code/test formatting only if gofmt changed files after prior commits:
+
+```bash
+git add ddd docs/project-knowledge
+git commit -m "test: verify ddd event module"
+```
+
+If there are no changes after verification, skip this commit and record that all verification commands passed.
+
+## Self-Review
+
+Spec coverage:
+
+- Package boundary `ddd/event`: Task 1.
+- Collection API and lifecycle: Task 2.
+- Dispatcher admission, no caller context, and bool return: Task 3.
+- Batch FIFO, batch-internal order, and handler order: Task 4.
+- Handler context, timeout, unhandled hook, panic recovery, and close behavior: Task 5.
+- Package docs and verification: Task 6.
+- Non-goal of changing `mediator`: enforced by file structure and Architecture Gate.
+
+Placeholder scan:
+
+- No placeholder tasks are intentionally left in the plan.
+- Each code-changing task includes concrete file paths, code snippets, commands, and expected results.
+
+Type consistency:
+
+- Public names match the spec: `Kind`, `Event`, `Collection`, `Handler`, `Dispatcher`, `NewCollection`, `NewDispatcher`.
+- Option names match the spec: `WithLogger`, `WithDelayClose`, `WithHandlerTimeout`, `WithContextFactory`, `WithUnhandledEventHandler`, `WithPanicHandler`, `WithBufferSize`.

--- a/docs/superpowers/plans/2026-05-10-ddd-event-implementation.md
+++ b/docs/superpowers/plans/2026-05-10-ddd-event-implementation.md
@@ -16,6 +16,21 @@
 - Project knowledge: `docs/project-knowledge/architecture.md`, `docs/project-knowledge/conventions.md`
 - Existing runtime reference: `mediator/option.go`, `mediator/mediator.go`
 
+## Post-Implementation Amendment
+
+After the original plan was executed, dispatcher observability was expanded from
+the approved design discussion:
+
+- accepted batches now receive a dispatcher-local `BatchID`
+- unhandled and panic hooks receive context structs that include `BatchID`
+- dispatcher lifecycle, rejected dispatches, unhandled events, nil context
+  factory results, close context errors, and recovered panics are logged at
+  explicit levels
+
+The canonical API and behavior are recorded in the spec and implementation. Some
+earlier task snippets below show the pre-amendment hook signatures and should be
+read as historical execution steps, not the final API.
+
 ## Architecture Gate
 
 - Gate level: Level 3, new DDD concept package and dispatch boundary.

--- a/docs/superpowers/specs/2026-05-10-ddd-event-design.md
+++ b/docs/superpowers/specs/2026-05-10-ddd-event-design.md
@@ -1,0 +1,336 @@
+# DDD Event Module Design
+
+Date: 2026-05-10
+Status: Draft for review
+
+## Purpose
+
+Add a new DDD-oriented domain event module without changing the existing
+`mediator` package. The existing `mediator` API remains compatible for current
+users. The new module provides a cleaner boundary for domain event collection
+and in-process dispatch inside one bounded context.
+
+The first module is:
+
+```text
+ddd/event
+```
+
+Future modules may use:
+
+```text
+ddd/message
+ddd/message/outbox
+```
+
+The `ddd/` directory is a namespace for DDD concept components. It is not a
+business application's Domain Layer directory.
+
+## Scope
+
+`ddd/event` is for domain events inside one bounded context.
+
+It is not:
+
+- an integration message bus
+- a broker abstraction
+- a transactional outbox implementation
+- a reliable delivery mechanism across process restarts
+
+Cross bounded-context or cross-service contracts belong in a future
+`ddd/message` package. Outbox reliability belongs under `ddd/message/outbox`.
+
+## Architecture Gate
+
+- Gate level: Level 3, because this introduces a new DDD concept package and a
+  new event dispatch boundary.
+- Bounded context / business capability: shared component library capability for
+  domain event collection and in-process dispatch.
+- Stable language / data authority: `Event` is an internal domain fact in one
+  bounded context. `Collection` records facts raised by an aggregate.
+  `Dispatcher` accepts event batches for in-process handling.
+- Affected aggregate, policy, or service: no business aggregate. Affects shared
+  event collection, event dispatch, handler subscription, and shutdown policy.
+- Invariants and rules: domain methods collect events only; application drains
+  after successful persistence; handlers are follow-up transactions; dispatch
+  admission does not report handler success.
+- Technical capability classification: `Collection` is Domain-facing;
+  `Dispatcher` is application/runtime orchestration; logger, timeout, panic
+  recovery, shutdown, and buffering are infrastructure concerns.
+- Layer ownership: Domain owns event definitions and collection. Application
+  owns the save-then-drain-then-dispatch timing. Infrastructure/runtime owns
+  handler execution mechanics.
+- Proceed / Stop: proceed with design only. Implementation requires a separate
+  plan.
+
+## Public API
+
+Proposed package:
+
+```go
+package event
+
+import "context"
+
+type Kind string
+
+type Event interface {
+    Kind() Kind
+}
+
+type Collection interface {
+    Add(Event) bool
+    Drain() []Event
+    Len() int
+}
+
+type Handler interface {
+    Listening() []Kind
+    Handle(context.Context, Event)
+}
+
+type Dispatcher interface {
+    Subscribe(Handler)
+    Dispatch(Event) bool
+    DispatchAll([]Event) bool
+    Close(context.Context) error
+}
+
+func NewCollection() Collection
+func NewDispatcher(opts ...Option) Dispatcher
+```
+
+`Handler.Handle` does not return an error. A handler represents a follow-up
+transaction or reaction. The previous application transaction does not observe
+the handler's result through `Dispatch`.
+
+`Dispatch` does not accept caller context. The caller's context usually belongs
+to the current synchronous request or command. Event handling is a later
+transaction and must not be canceled just because the original request returned.
+
+## Collection Semantics
+
+`Collection` is intentionally small and does not use `sync.Pool`.
+
+```go
+type collection struct {
+    events  []Event
+    drained bool
+}
+```
+
+Rules:
+
+- `Add(event)` returns `true` when the event is accepted.
+- `Add(event)` returns `false` after the collection has been drained.
+- `Drain()` returns currently collected events in add order.
+- `Drain()` closes the collection.
+- Repeated `Drain()` returns no events.
+- `Len()` returns the count of undrained events.
+- The collection does not dispatch events.
+- The collection does not promise concurrent safety.
+
+No preallocation is required. The wrapper is small, and pooling would complicate
+the lifetime of drained slices.
+
+## Application Usage
+
+Aggregate methods collect facts:
+
+```go
+type Order struct {
+    events event.Collection
+}
+
+func (o *Order) Pay() {
+    // Change aggregate state...
+    o.events.Add(EventOrderPaid{OrderID: o.ID})
+}
+
+func (o *Order) Events() event.Collection {
+    return o.events
+}
+```
+
+Application services dispatch after persistence:
+
+```go
+order.Pay()
+
+repo.Save(order)
+
+dispatcher.DispatchAll(order.Events().Drain())
+```
+
+If a follow-up action must affect the current use case result, it should be an
+explicit application service step or domain rule, not a domain event handler.
+
+## Dispatch Semantics
+
+`Dispatch` and `DispatchAll` are admission APIs.
+
+- `true` means the dispatcher accepted the event batch.
+- `false` means the dispatcher is closing or closed and did not accept the
+  batch.
+- The return value does not report handler success or failure.
+
+`Dispatch(event)` is equivalent to submitting one batch containing one event.
+
+`DispatchAll(events)` submits one batch. It must not be implemented as multiple
+independent `Dispatch` calls because other batches could interleave between
+events from the same aggregate transaction.
+
+Empty batches return `true` and do not enqueue work.
+
+## Ordering
+
+The default dispatcher uses one background worker.
+
+Ordering guarantees:
+
+- batches are processed FIFO by acceptance order
+- events inside one batch are processed in slice order
+- handlers for one event are called in subscription order
+- no event from another batch interleaves into a running batch
+
+This favors clear semantics over throughput. A future concurrent dispatcher may
+be added as a separate implementation, but it must document weaker ordering if
+it allows batch concurrency.
+
+## Handler Context
+
+The dispatcher creates handler contexts. Handler context represents event
+processing lifecycle, not request lifecycle.
+
+Supported options:
+
+```go
+type Option func(*dispatcher)
+
+func WithLogger(logger *slog.Logger) Option
+func WithDelayClose(d time.Duration) Option
+func WithHandlerTimeout(timeout time.Duration) Option
+func WithContextFactory(fn func(context.Context, Event) context.Context) Option
+func WithUnhandledEventHandler(fn func(Event)) Option
+func WithPanicHandler(fn func(Event, any, []byte)) Option
+func WithBufferSize(n int) Option
+```
+
+Default values:
+
+- logger: `slog.Default()`
+- delay close: `5s`
+- handler timeout: `0`, meaning no timeout
+- buffer size: `1024`
+- unhandled event handler: none
+- panic handler: none; panic is logged by default
+
+The option set intentionally resembles `mediator` where the semantics still
+match. The new module does not expose `Concurrent` in the default dispatcher
+because concurrency would weaken batch FIFO ordering.
+
+## Queue And Shutdown
+
+The dispatcher queue stores batches:
+
+```go
+type batch struct {
+    events []Event
+}
+```
+
+When open:
+
+- `Dispatch` and `DispatchAll` enqueue a batch and return `true`.
+- If the buffer is full, dispatch waits for space.
+
+When closing or closed:
+
+- new dispatch calls return `false`.
+- already accepted batches continue to drain.
+- `Close(ctx)` waits for accepted batches to finish or returns `ctx.Err()`.
+
+`WithDelayClose` delays the transition into closing, matching the existing
+`mediator` shutdown style where useful.
+
+## Panic And Unhandled Events
+
+Handler panics are recovered by the dispatcher. A panic in one handler must not
+stop later handlers, later events in the same batch, or later batches.
+
+If no handler subscribes to an event:
+
+- default behavior is no-op
+- an optional unhandled event hook may observe it
+
+No handler is not an error. Domain events can be raised for optional reactions.
+
+## Testing Strategy
+
+Tests should verify public semantics.
+
+Collection tests:
+
+- `Add` accepts events before drain
+- events drain in add order
+- `Len` is updated before and after drain
+- `Add` returns `false` after drain
+- repeated `Drain` returns no events
+
+Dispatcher admission tests:
+
+- `Dispatch` and `DispatchAll` return `true` while open
+- `Dispatch` and `DispatchAll` return `false` after close starts
+- empty batch returns `true`
+- `Dispatch` behaves as a single-event batch
+
+Ordering tests:
+
+- batch FIFO
+- batch-internal event order
+- handler subscription order
+- `DispatchAll` batch is not interleaved by another batch
+
+Runtime tests:
+
+- handler panic is recovered
+- panic does not block later handlers/events/batches
+- unhandled event hook is called when configured
+- handler timeout is applied when configured
+- context factory is applied when configured
+- `Close(ctx)` drains accepted batches
+- `Close(ctx)` returns `ctx.Err()` on timeout
+
+## Documentation Requirements
+
+Package documentation must state:
+
+```text
+ddd/event is for domain events inside one bounded context.
+It is not an integration message bus.
+It does not provide reliable delivery across process restarts.
+```
+
+```text
+Dispatch only reports whether a batch was accepted.
+It does not report handler success or failure.
+Handlers represent follow-up transactions and own their own error policy.
+```
+
+```text
+The caller's context is intentionally not passed to Dispatch.
+Handler context is created by the dispatcher and represents event-processing
+lifecycle.
+```
+
+## Open Non-Goals
+
+These are explicitly outside the first implementation:
+
+- cross-service integration events/messages
+- outbox persistence schema
+- retry or dead-letter policy
+- concurrent dispatch implementation
+- handler error aggregation
+- `sync.Pool` collection reuse
+- modifying the existing `mediator` package

--- a/docs/superpowers/specs/2026-05-10-ddd-event-design.md
+++ b/docs/superpowers/specs/2026-05-10-ddd-event-design.md
@@ -90,6 +90,15 @@ type PanicContext struct {
     Stack   []byte
 }
 
+type CloseInterruptedContext struct {
+    Error             error
+    PendingBatchCount int
+    PendingEventCount int
+    InFlightBatchID   uint64
+    PendingBatchIDs   []uint64
+    PendingEventKinds []Kind
+}
+
 type Collection interface {
     Add(Event) bool
     Drain() []Event
@@ -225,6 +234,7 @@ func WithHandlerTimeout(timeout time.Duration) Option
 func WithContextFactory(fn func(context.Context, Event) context.Context) Option
 func WithUnhandledEventHandler(fn func(UnhandledContext)) Option
 func WithPanicHandler(fn func(PanicContext)) Option
+func WithCloseInterruptedHandler(fn func(CloseInterruptedContext)) Option
 func WithBufferSize(n int) Option
 ```
 
@@ -236,6 +246,7 @@ Default values:
 - buffer size: `1024`
 - unhandled event handler: none
 - panic handler: none; panic is logged by default
+- close interrupted handler: none; interruption is logged by default
 
 The option set intentionally resembles `mediator` where the semantics still
 match. The new module does not expose `Concurrent` in the default dispatcher
@@ -263,6 +274,19 @@ When closing or closed:
 - already accepted batches continue to drain.
 - `Close(ctx)` waits for accepted batches to finish or returns `ctx.Err()`.
 
+If `Close(ctx)` is interrupted before accepted batches finish, the dispatcher
+enters a forced shutdown state:
+
+- new dispatch calls still return `false`.
+- the current handler context is canceled through the dispatcher root context.
+- the worker stops taking additional queued batches.
+- remaining queued batches are considered abandoned in memory.
+- `Close(ctx)` returns the caller context error.
+
+This does not provide reliability. It makes the failure explicit: a non-nil
+`Close` error means the dispatcher did not confirm all accepted batches were
+handled before the process shutdown window expired.
+
 `WithDelayClose` delays the transition into closing, matching the existing
 `mediator` shutdown style where useful.
 
@@ -279,6 +303,7 @@ business identifier and is not stable across process restarts.
 - unhandled event warning logs
 - recovered panic error logs
 - context factory warning logs
+- close interruption diagnostics
 
 The dispatcher logs its autonomous runtime behavior:
 
@@ -286,11 +311,17 @@ The dispatcher logs its autonomous runtime behavior:
 - `Warn`: non-empty dispatch rejected because the dispatcher is closing/closed
 - `Warn`: event has no handler and no unhandled hook is configured
 - `Warn`: context factory returns `nil`
-- `Warn`: close is interrupted by caller context cancellation or timeout
+- `Warn`: close is interrupted by caller context cancellation or timeout,
+  including pending batch/event summary
 - `Error`: handler panic when no panic hook is configured
 
 The dispatcher does not log accepted batches, handler start/end, empty batches,
 or unhandled events when a user-provided unhandled hook is configured.
+
+When `Close(ctx)` is interrupted, an optional close interrupted hook may observe
+a `CloseInterruptedContext`. The context is a diagnostic snapshot, not a replay
+contract. It may include pending counts, in-flight batch ID, pending batch IDs,
+and pending event kinds. It must not include full event values by default.
 
 ## Panic And Unhandled Events
 
@@ -342,6 +373,8 @@ Runtime tests:
 - nil context factory results are logged as warnings
 - `Close(ctx)` drains accepted batches
 - `Close(ctx)` returns `ctx.Err()` on timeout
+- `Close(ctx)` interruption reports pending batch/event diagnostics
+- `Close(ctx)` interruption stops the worker from taking more queued batches
 - close lifecycle and close context errors are logged
 
 ## Documentation Requirements

--- a/docs/superpowers/specs/2026-05-10-ddd-event-design.md
+++ b/docs/superpowers/specs/2026-05-10-ddd-event-design.md
@@ -78,6 +78,18 @@ type Event interface {
     Kind() Kind
 }
 
+type UnhandledContext struct {
+    BatchID uint64
+    Event   Event
+}
+
+type PanicContext struct {
+    BatchID uint64
+    Event   Event
+    Panic   any
+    Stack   []byte
+}
+
 type Collection interface {
     Add(Event) bool
     Drain() []Event
@@ -211,8 +223,8 @@ func WithLogger(logger *slog.Logger) Option
 func WithDelayClose(d time.Duration) Option
 func WithHandlerTimeout(timeout time.Duration) Option
 func WithContextFactory(fn func(context.Context, Event) context.Context) Option
-func WithUnhandledEventHandler(fn func(Event)) Option
-func WithPanicHandler(fn func(Event, any, []byte)) Option
+func WithUnhandledEventHandler(fn func(UnhandledContext)) Option
+func WithPanicHandler(fn func(PanicContext)) Option
 func WithBufferSize(n int) Option
 ```
 
@@ -235,6 +247,7 @@ The dispatcher queue stores batches:
 
 ```go
 type batch struct {
+    id     uint64
     events []Event
 }
 ```
@@ -253,6 +266,32 @@ When closing or closed:
 `WithDelayClose` delays the transition into closing, matching the existing
 `mediator` shutdown style where useful.
 
+## Observability
+
+Each accepted non-empty batch receives a dispatcher-local `BatchID`. The ID is
+monotonic within one dispatcher instance and is only for diagnostics. It is not a
+business identifier and is not stable across process restarts.
+
+`BatchID` is included in:
+
+- unhandled event hook context
+- panic hook context
+- unhandled event warning logs
+- recovered panic error logs
+- context factory warning logs
+
+The dispatcher logs its autonomous runtime behavior:
+
+- `Info`: close started and close completed
+- `Warn`: non-empty dispatch rejected because the dispatcher is closing/closed
+- `Warn`: event has no handler and no unhandled hook is configured
+- `Warn`: context factory returns `nil`
+- `Warn`: close is interrupted by caller context cancellation or timeout
+- `Error`: handler panic when no panic hook is configured
+
+The dispatcher does not log accepted batches, handler start/end, empty batches,
+or unhandled events when a user-provided unhandled hook is configured.
+
 ## Panic And Unhandled Events
 
 Handler panics are recovered by the dispatcher. A panic in one handler must not
@@ -262,6 +301,7 @@ If no handler subscribes to an event:
 
 - default behavior is no-op
 - an optional unhandled event hook may observe it
+- if no hook is configured, the dispatcher logs a warning
 
 No handler is not an error. Domain events can be raised for optional reactions.
 
@@ -296,10 +336,13 @@ Runtime tests:
 - handler panic is recovered
 - panic does not block later handlers/events/batches
 - unhandled event hook is called when configured
+- unhandled events without a hook are logged as warnings
 - handler timeout is applied when configured
 - context factory is applied when configured
+- nil context factory results are logged as warnings
 - `Close(ctx)` drains accepted batches
 - `Close(ctx)` returns `ctx.Err()` on timeout
+- close lifecycle and close context errors are logged
 
 ## Documentation Requirements
 

--- a/docs/superpowers/specs/2026-05-10-ddd-event-design.md
+++ b/docs/superpowers/specs/2026-05-10-ddd-event-design.md
@@ -90,13 +90,15 @@ type PanicContext struct {
     Stack   []byte
 }
 
+type PendingBatch struct {
+    BatchID uint64
+    Events  []Event
+}
+
 type CloseInterruptedContext struct {
-    Error             error
-    PendingBatchCount int
-    PendingEventCount int
-    InFlightBatchID   uint64
-    PendingBatchIDs   []uint64
-    PendingEventKinds []Kind
+    Error           error
+    InFlightBatchID uint64
+    PendingBatches  []PendingBatch
 }
 
 type Collection interface {
@@ -320,8 +322,11 @@ or unhandled events when a user-provided unhandled hook is configured.
 
 When `Close(ctx)` is interrupted, an optional close interrupted hook may observe
 a `CloseInterruptedContext`. The context is a diagnostic snapshot, not a replay
-contract. It may include pending counts, in-flight batch ID, pending batch IDs,
-and pending event kinds. It must not include full event values by default.
+contract. It includes the in-flight batch ID and queued pending batches with
+their original events so callers can persist best-effort offline compensation
+clues. It does not include in-flight events because their handler state is
+unknown. Warning logs still include derived counts, batch IDs, and event kinds,
+but these summaries are not duplicated in the hook context API.
 
 ## Panic And Unhandled Events
 

--- a/mediator/default.go
+++ b/mediator/default.go
@@ -8,6 +8,9 @@ func (nopMediator) Dispatch(Event) error   { return ErrMediatorClosed }
 func (nopMediator) Subscribe(EventHandler) {}
 
 // SetDefault sets the default global mediator.
+//
+// Deprecated: use explicit github.com/go-jimu/components/ddd/event.Dispatcher
+// instances for new domain event code.
 func SetDefault(m Mediator) {
 	if m == nil {
 		return
@@ -15,14 +18,20 @@ func SetDefault(m Mediator) {
 	defaultMediator = m
 }
 
+// Deprecated: use explicit github.com/go-jimu/components/ddd/event.Dispatcher
+// instances for new domain event code.
 func Default() Mediator {
 	return defaultMediator
 }
 
+// Deprecated: use explicit github.com/go-jimu/components/ddd/event.Dispatcher
+// instances for new domain event code.
 func Dispatch(ev Event) {
 	defaultMediator.Dispatch(ev)
 }
 
+// Deprecated: use explicit github.com/go-jimu/components/ddd/event.Dispatcher
+// instances for new domain event code.
 func Subscribe(hdl EventHandler) {
 	defaultMediator.Subscribe(hdl)
 }

--- a/mediator/doc.go
+++ b/mediator/doc.go
@@ -1,0 +1,6 @@
+// Package mediator provides the legacy in-process mediator.
+//
+// Deprecated: use github.com/go-jimu/components/ddd/event for new domain event
+// code. Package mediator is kept for backward compatibility and will only
+// receive compatibility fixes.
+package mediator

--- a/mediator/event.go
+++ b/mediator/event.go
@@ -13,14 +13,22 @@ import (
 
 type (
 	// EventKind 事件类型描述.
+	//
+	// Deprecated: use github.com/go-jimu/components/ddd/event.Kind for new
+	// domain event code.
 	EventKind string
 
+	// Deprecated: use github.com/go-jimu/components/ddd/event.Handler for new
+	// domain event code.
 	EventHandler interface {
 		Listening() []EventKind
 		Handle(context.Context, Event)
 	}
 
 	// Event 事件接口.
+	//
+	// Deprecated: use github.com/go-jimu/components/ddd/event.Event for new
+	// domain event code.
 	Event interface {
 		Kind() EventKind
 	}
@@ -30,6 +38,8 @@ type (
 		raised atomic.Bool
 	}
 
+	// Deprecated: use github.com/go-jimu/components/ddd/event.Collection for new
+	// domain event code.
 	EventCollection interface {
 		Add(Event)
 		Raise(Mediator)
@@ -39,6 +49,8 @@ type (
 
 var _ EventCollection = (*eventCollection)(nil)
 
+// Deprecated: use github.com/go-jimu/components/ddd/event.NewCollection for new
+// domain event code.
 func NewEventCollection() EventCollection {
 	return &eventCollection{events: make([]Event, 0)}
 }

--- a/mediator/mediator.go
+++ b/mediator/mediator.go
@@ -11,12 +11,18 @@ import (
 
 type (
 	// Mediator is the interface that wraps the methods of a mediator.
+	//
+	// Deprecated: use github.com/go-jimu/components/ddd/event.Dispatcher for new
+	// domain event code.
 	Mediator interface {
 		Dispatch(Event) error
 		Subscribe(EventHandler)
 	}
 
 	// InMemMediator is a simple in-memory mediator implementation.
+	//
+	// Deprecated: use github.com/go-jimu/components/ddd/event.NewDispatcher for
+	// new domain event code.
 	InMemMediator struct {
 		timeout            time.Duration
 		handlers           map[EventKind][]EventHandler
@@ -33,6 +39,9 @@ type (
 	}
 
 	// Options is the options for the mediator.
+	//
+	// Deprecated: use github.com/go-jimu/components/ddd/event options for new
+	// domain event code.
 	Options struct {
 		Timeout    string `json:"timeout" yaml:"timeout" toml:"timeout"`
 		Concurrent int    `json:"concurrent" yaml:"concurrent" toml:"concurrent"`
@@ -40,11 +49,17 @@ type (
 )
 
 var (
-	_                   Mediator = (*InMemMediator)(nil)
-	ErrMediatorClosed            = errors.New("mediator is closed")
-	ErrNoHandlerMatched          = errors.New("no matching event handler found")
+	_ Mediator = (*InMemMediator)(nil)
+	// Deprecated: use github.com/go-jimu/components/ddd/event.Dispatcher return
+	// values for new domain event code.
+	ErrMediatorClosed = errors.New("mediator is closed")
+	// Deprecated: use github.com/go-jimu/components/ddd/event.WithUnhandledEventHandler
+	// for new domain event code.
+	ErrNoHandlerMatched = errors.New("no matching event handler found")
 )
 
+// Deprecated: use github.com/go-jimu/components/ddd/event.NewDispatcher for new
+// domain event code.
 func NewInMemMediator(opt Options, opts ...Option) Mediator {
 	if opt.Concurrent < 1 {
 		opt.Concurrent = 1

--- a/mediator/option.go
+++ b/mediator/option.go
@@ -7,9 +7,15 @@ import (
 )
 
 // Option configures an InMemMediator during construction.
+//
+// Deprecated: use github.com/go-jimu/components/ddd/event options for new
+// domain event code.
 type Option func(*InMemMediator)
 
 // WithLogger sets the logger for the mediator.
+//
+// Deprecated: use github.com/go-jimu/components/ddd/event.WithLogger for new
+// domain event code.
 func WithLogger(logger *slog.Logger) Option {
 	return func(m *InMemMediator) {
 		if logger != nil {
@@ -19,6 +25,9 @@ func WithLogger(logger *slog.Logger) Option {
 }
 
 // WithDelayClose sets the delay before the mediator starts rejecting new events during shutdown.
+//
+// Deprecated: use github.com/go-jimu/components/ddd/event.WithDelayClose for
+// new domain event code.
 func WithDelayClose(d time.Duration) Option {
 	return func(m *InMemMediator) {
 		if d >= 0 {
@@ -28,6 +37,9 @@ func WithDelayClose(d time.Duration) Option {
 }
 
 // WithTimeout sets the context timeout for each handler invocation.
+//
+// Deprecated: use github.com/go-jimu/components/ddd/event.WithHandlerTimeout for
+// new domain event code.
 func WithTimeout(timeout time.Duration) Option {
 	return func(m *InMemMediator) {
 		if timeout >= 0 {
@@ -37,6 +49,9 @@ func WithTimeout(timeout time.Duration) Option {
 }
 
 // WithGenContext sets a function to derive a new context for each event dispatch.
+//
+// Deprecated: use github.com/go-jimu/components/ddd/event.WithContextFactory for
+// new domain event code.
 func WithGenContext(fn func(ctx context.Context, ev Event) context.Context) Option {
 	return func(m *InMemMediator) {
 		m.genContextFn = fn
@@ -44,6 +59,9 @@ func WithGenContext(fn func(ctx context.Context, ev Event) context.Context) Opti
 }
 
 // WithOrphanEventHandler sets a fallback handler for events with no registered handler.
+//
+// Deprecated: use github.com/go-jimu/components/ddd/event.WithUnhandledEventHandler
+// for new domain event code.
 func WithOrphanEventHandler(fn func(Event) error) Option {
 	return func(m *InMemMediator) {
 		m.orphanEventHandler = fn


### PR DESCRIPTION
## Summary
- Add a new ddd/event package for in-process domain event collection and dispatch without changing mediator behavior.
- Add dispatcher ordering, shutdown, observability, panic/unhandled hooks, and forced shutdown diagnostics with pending batches.
- Mark mediator as legacy for new domain event code and add migration documentation.

## Test Plan
- go test -race ./... -count=1
- go doc ./ddd/event
- go doc ./mediator
- superpowers-memory verify