### PR TITLE
Refine ddd event dispatcher API

### DIFF
--- a/ddd/event/dispatcher.go
+++ b/ddd/event/dispatcher.go
@@ -18,7 +18,7 @@ type batch struct {
 	events []Event
 }
 
-type dispatcher struct {
+type InMemoryDispatcher struct {
 	mu                      sync.Mutex
 	notEmpty                *sync.Cond
 	notFull                 *sync.Cond
@@ -42,15 +42,14 @@ type dispatcher struct {
 }
 
 var (
-	_ Dispatcher = (*dispatcher)(nil)
-	_ Subscriber = (*dispatcher)(nil)
-	_ Bus        = (*dispatcher)(nil)
+	_ Dispatcher = (*InMemoryDispatcher)(nil)
+	_ Subscriber = (*InMemoryDispatcher)(nil)
 )
 
 // NewDispatcher creates an in-process dispatcher with one background worker.
-func NewDispatcher(opts ...Option) Bus {
+func NewDispatcher(opts ...Option) *InMemoryDispatcher {
 	rootCtx, rootCancel := context.WithCancel(context.Background())
-	d := &dispatcher{
+	d := &InMemoryDispatcher{
 		done:       make(chan struct{}),
 		handlers:   make(map[Kind][]Handler),
 		logger:     slog.Default(),
@@ -70,7 +69,7 @@ func NewDispatcher(opts ...Option) Bus {
 	return d
 }
 
-func (d *dispatcher) Subscribe(handler Handler) {
+func (d *InMemoryDispatcher) Subscribe(handler Handler) {
 	if handler == nil {
 		return
 	}
@@ -86,14 +85,14 @@ func (d *dispatcher) Subscribe(handler Handler) {
 	}
 }
 
-func (d *dispatcher) Dispatch(event Event) error {
+func (d *InMemoryDispatcher) Dispatch(event Event) error {
 	if event == nil {
 		return nil
 	}
 	return d.DispatchAll([]Event{event})
 }
 
-func (d *dispatcher) DispatchAll(events []Event) error {
+func (d *InMemoryDispatcher) DispatchAll(events []Event) error {
 	if len(events) == 0 {
 		return nil
 	}
@@ -118,7 +117,7 @@ func (d *dispatcher) DispatchAll(events []Event) error {
 	return nil
 }
 
-func (d *dispatcher) Close(ctx context.Context) error {
+func (d *InMemoryDispatcher) Close(ctx context.Context) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -162,7 +161,7 @@ func (d *dispatcher) Close(ctx context.Context) error {
 	}
 }
 
-func (d *dispatcher) beginClose() bool {
+func (d *InMemoryDispatcher) beginClose() bool {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -175,7 +174,7 @@ func (d *dispatcher) beginClose() bool {
 	return true
 }
 
-func (d *dispatcher) interruptClose(err error) (CloseInterruptedContext, bool) {
+func (d *InMemoryDispatcher) interruptClose(err error) (CloseInterruptedContext, bool) {
 	d.mu.Lock()
 	started := !d.closed
 	d.closed = true
@@ -189,7 +188,7 @@ func (d *dispatcher) interruptClose(err error) (CloseInterruptedContext, bool) {
 	return snapshot, started
 }
 
-func (d *dispatcher) closeInterruptedSnapshotLocked(err error) CloseInterruptedContext {
+func (d *InMemoryDispatcher) closeInterruptedSnapshotLocked(err error) CloseInterruptedContext {
 	snapshot := CloseInterruptedContext{
 		Error:           err,
 		InFlightBatchID: d.inFlightBatchID,
@@ -205,7 +204,7 @@ func (d *dispatcher) closeInterruptedSnapshotLocked(err error) CloseInterruptedC
 	return snapshot
 }
 
-func (d *dispatcher) reportCloseInterrupted(snapshot CloseInterruptedContext) {
+func (d *InMemoryDispatcher) reportCloseInterrupted(snapshot CloseInterruptedContext) {
 	pendingBatchIDs, pendingEventKinds, pendingEventCount := closeInterruptedSummary(snapshot)
 	d.logger.Warn("domain event dispatcher close interrupted",
 		slog.Any("error", snapshot.Error),
@@ -241,7 +240,7 @@ func closeInterruptedSummary(snapshot CloseInterruptedContext) ([]uint64, []Kind
 	return batchIDs, eventKinds, eventCount
 }
 
-func (d *dispatcher) run() {
+func (d *InMemoryDispatcher) run() {
 	defer close(d.done)
 
 	for {
@@ -255,7 +254,7 @@ func (d *dispatcher) run() {
 	}
 }
 
-func (d *dispatcher) nextBatch() (batch, bool) {
+func (d *InMemoryDispatcher) nextBatch() (batch, bool) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -277,13 +276,13 @@ func (d *dispatcher) nextBatch() (batch, bool) {
 	return next, true
 }
 
-func (d *dispatcher) setInFlight(batchID uint64) {
+func (d *InMemoryDispatcher) setInFlight(batchID uint64) {
 	d.mu.Lock()
 	d.inFlightBatchID = batchID
 	d.mu.Unlock()
 }
 
-func (d *dispatcher) clearInFlight(batchID uint64) {
+func (d *InMemoryDispatcher) clearInFlight(batchID uint64) {
 	d.mu.Lock()
 	if d.inFlightBatchID == batchID {
 		d.inFlightBatchID = 0
@@ -291,13 +290,13 @@ func (d *dispatcher) clearInFlight(batchID uint64) {
 	d.mu.Unlock()
 }
 
-func (d *dispatcher) handleBatch(next batch) {
+func (d *InMemoryDispatcher) handleBatch(next batch) {
 	for _, event := range next.events {
 		d.handleEvent(next.id, event)
 	}
 }
 
-func (d *dispatcher) handleEvent(batchID uint64, event Event) {
+func (d *InMemoryDispatcher) handleEvent(batchID uint64, event Event) {
 	if event == nil {
 		return
 	}
@@ -322,7 +321,7 @@ func (d *dispatcher) handleEvent(batchID uint64, event Event) {
 	}
 }
 
-func (d *dispatcher) handleOne(batchID uint64, handler Handler, event Event) {
+func (d *InMemoryDispatcher) handleOne(batchID uint64, handler Handler, event Event) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			stack := debug.Stack()
@@ -349,7 +348,7 @@ func (d *dispatcher) handleOne(batchID uint64, handler Handler, event Event) {
 	handler.Handle(ctx, event)
 }
 
-func (d *dispatcher) handlerContext(batchID uint64, event Event) (context.Context, context.CancelFunc) {
+func (d *InMemoryDispatcher) handlerContext(batchID uint64, event Event) (context.Context, context.CancelFunc) {
 	var (
 		ctx    context.Context
 		cancel context.CancelFunc

--- a/ddd/event/dispatcher.go
+++ b/ddd/event/dispatcher.go
@@ -82,16 +82,16 @@ func (d *dispatcher) Subscribe(handler Handler) {
 	}
 }
 
-func (d *dispatcher) Dispatch(event Event) bool {
+func (d *dispatcher) Dispatch(event Event) error {
 	if event == nil {
-		return true
+		return nil
 	}
 	return d.DispatchAll([]Event{event})
 }
 
-func (d *dispatcher) DispatchAll(events []Event) bool {
+func (d *dispatcher) DispatchAll(events []Event) error {
 	if len(events) == 0 {
-		return true
+		return nil
 	}
 
 	copied := make([]Event, len(events))
@@ -104,14 +104,14 @@ func (d *dispatcher) DispatchAll(events []Event) bool {
 	if d.closed {
 		d.mu.Unlock()
 		d.logger.Warn("domain event dispatch rejected", slog.Int("event_count", len(copied)))
-		return false
+		return ErrDispatcherClosed
 	}
 
 	d.nextBatchID++
 	d.queue = append(d.queue, batch{id: d.nextBatchID, events: copied})
 	d.notEmpty.Signal()
 	d.mu.Unlock()
-	return true
+	return nil
 }
 
 func (d *dispatcher) Close(ctx context.Context) error {

--- a/ddd/event/dispatcher.go
+++ b/ddd/event/dispatcher.go
@@ -41,10 +41,14 @@ type dispatcher struct {
 	rootCancel              context.CancelFunc
 }
 
-var _ Dispatcher = (*dispatcher)(nil)
+var (
+	_ Dispatcher = (*dispatcher)(nil)
+	_ Subscriber = (*dispatcher)(nil)
+	_ Bus        = (*dispatcher)(nil)
+)
 
 // NewDispatcher creates an in-process dispatcher with one background worker.
-func NewDispatcher(opts ...Option) Dispatcher {
+func NewDispatcher(opts ...Option) Bus {
 	rootCtx, rootCancel := context.WithCancel(context.Background())
 	d := &dispatcher{
 		done:       make(chan struct{}),

--- a/ddd/event/dispatcher_test.go
+++ b/ddd/event/dispatcher_test.go
@@ -23,6 +23,18 @@ func (h handlerFunc) Handle(ctx context.Context, ev event.Event) {
 	}
 }
 
+type dispatchOnly struct{}
+
+func (dispatchOnly) Dispatch(event.Event) error      { return nil }
+func (dispatchOnly) DispatchAll([]event.Event) error { return nil }
+func (dispatchOnly) Close(context.Context) error     { return nil }
+
+// Intent: producer-only implementations should satisfy Dispatcher without
+// supporting subscriptions.
+func TestDispatcherInterfaceDoesNotRequireSubscription(t *testing.T) {
+	var _ event.Dispatcher = dispatchOnly{}
+}
+
 type logRecord struct {
 	level   slog.Level
 	message string

--- a/ddd/event/dispatcher_test.go
+++ b/ddd/event/dispatcher_test.go
@@ -91,7 +91,7 @@ func TestDispatcherDispatchAcceptedWhileOpen(t *testing.T) {
 		},
 	})
 
-	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.NoError(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
 	require.Equal(t, event.Kind("order.paid"), (<-called).Kind())
 }
 
@@ -101,18 +101,18 @@ func TestDispatcherDispatchAllEmptyBatchAccepted(t *testing.T) {
 	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
 	defer dispatcher.Close(context.Background())
 
-	require.True(t, dispatcher.DispatchAll(nil))
-	require.True(t, dispatcher.DispatchAll([]event.Event{}))
+	require.NoError(t, dispatcher.DispatchAll(nil))
+	require.NoError(t, dispatcher.DispatchAll([]event.Event{}))
 }
 
-// Intent: once the dispatcher is closed, new event batches are rejected with
-// false instead of reporting handler errors.
+// Intent: once the dispatcher is closed, new event batches are rejected with a
+// dispatch error instead of reporting handler errors.
 func TestDispatcherRejectsAfterClose(t *testing.T) {
 	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
 	require.NoError(t, dispatcher.Close(context.Background()))
 
-	require.False(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
-	require.False(t, dispatcher.DispatchAll([]event.Event{testEvent{kind: "order.paid"}}))
+	require.ErrorIs(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}), event.ErrDispatcherClosed)
+	require.ErrorIs(t, dispatcher.DispatchAll([]event.Event{testEvent{kind: "order.paid"}}), event.ErrDispatcherClosed)
 }
 
 // Intent: rejected dispatches happen in a background component, so they should
@@ -125,7 +125,7 @@ func TestDispatcherLogsRejectedDispatch(t *testing.T) {
 	)
 	require.NoError(t, dispatcher.Close(context.Background()))
 
-	require.False(t, dispatcher.DispatchAll([]event.Event{testEvent{kind: "order.paid"}}))
+	require.ErrorIs(t, dispatcher.DispatchAll([]event.Event{testEvent{kind: "order.paid"}}), event.ErrDispatcherClosed)
 
 	record := receiveLogWithin(t, "rejected dispatch log", records)
 	for record.message != "domain event dispatch rejected" {
@@ -144,7 +144,7 @@ func TestDispatcherRejectsAfterDelayCloseCancel(t *testing.T) {
 	cancel()
 	require.ErrorIs(t, dispatcher.Close(ctx), context.Canceled)
 
-	require.False(t, dispatcher.DispatchAll([]event.Event{testEvent{kind: "order.paid"}}))
+	require.ErrorIs(t, dispatcher.DispatchAll([]event.Event{testEvent{kind: "order.paid"}}), event.ErrDispatcherClosed)
 }
 
 // Intent: close waits for already accepted work to finish before returning.
@@ -163,7 +163,7 @@ func TestDispatcherCloseDrainsAcceptedBatches(t *testing.T) {
 		},
 	})
 
-	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.NoError(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
 	<-started
 
 	var wg sync.WaitGroup
@@ -217,11 +217,11 @@ func TestDispatcherDispatchAllBatchDoesNotInterleave(t *testing.T) {
 		},
 	})
 
-	require.True(t, dispatcher.DispatchAll([]event.Event{
+	require.NoError(t, dispatcher.DispatchAll([]event.Event{
 		testEvent{kind: "order.event", name: "a1"},
 		testEvent{kind: "order.event", name: "a2"},
 	}))
-	require.True(t, dispatcher.DispatchAll([]event.Event{
+	require.NoError(t, dispatcher.DispatchAll([]event.Event{
 		testEvent{kind: "order.event", name: "b1"},
 		testEvent{kind: "order.event", name: "b2"},
 	}))
@@ -248,7 +248,7 @@ func TestDispatcherHandlersRunInSubscriptionOrder(t *testing.T) {
 		handle: func(context.Context, event.Event) { seen <- "second" },
 	})
 
-	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.NoError(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
 	require.Equal(t, "first", <-seen)
 	require.Equal(t, "second", <-seen)
 }
@@ -265,7 +265,7 @@ func TestDispatcherUnhandledEventHook(t *testing.T) {
 	)
 	defer dispatcher.Close(context.Background())
 
-	require.True(t, dispatcher.Dispatch(testEvent{kind: "unknown"}))
+	require.NoError(t, dispatcher.Dispatch(testEvent{kind: "unknown"}))
 	ctx := receiveWithin(t, "unhandled event", unhandled)
 	require.Equal(t, uint64(1), ctx.BatchID)
 	require.Equal(t, event.Kind("unknown"), ctx.Event.Kind())
@@ -281,7 +281,7 @@ func TestDispatcherLogsUnhandledEventWithoutHook(t *testing.T) {
 	)
 	defer dispatcher.Close(context.Background())
 
-	require.True(t, dispatcher.Dispatch(testEvent{kind: "unknown"}))
+	require.NoError(t, dispatcher.Dispatch(testEvent{kind: "unknown"}))
 
 	record := receiveLogWithin(t, "unhandled event log", records)
 	require.Equal(t, slog.LevelWarn, record.level)
@@ -316,7 +316,7 @@ func TestDispatcherRecoversPanicAndContinues(t *testing.T) {
 		},
 	})
 
-	require.True(t, dispatcher.DispatchAll([]event.Event{
+	require.NoError(t, dispatcher.DispatchAll([]event.Event{
 		testEvent{kind: "order.event", name: "first"},
 		testEvent{kind: "order.event", name: "second"},
 	}))
@@ -351,7 +351,7 @@ func TestDispatcherContextFactory(t *testing.T) {
 		},
 	})
 
-	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.NoError(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
 	require.Equal(t, "dispatcher-context", <-valueCh)
 }
 
@@ -377,7 +377,7 @@ func TestDispatcherLogsNilContextFactory(t *testing.T) {
 		},
 	})
 
-	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.NoError(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
 	receiveWithin(t, "handler after nil context factory", handled)
 	record := receiveLogWithin(t, "nil context factory log", records)
 	require.Equal(t, slog.LevelWarn, record.level)
@@ -404,7 +404,7 @@ func TestDispatcherHandlerTimeout(t *testing.T) {
 		},
 	})
 
-	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.NoError(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
 	require.ErrorIs(t, <-done, context.DeadlineExceeded)
 }
 
@@ -420,7 +420,7 @@ func TestDispatcherCloseReturnsContextErrorOnTimeout(t *testing.T) {
 		},
 	})
 
-	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.NoError(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
@@ -446,9 +446,9 @@ func TestDispatcherLogsCloseContextError(t *testing.T) {
 		},
 	})
 
-	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.NoError(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
 	<-started
-	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
+	require.NoError(t, dispatcher.Dispatch(testEvent{kind: "order.paid"}))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()
@@ -492,12 +492,12 @@ func TestDispatcherCloseInterruptedHookReportsAbandonedWork(t *testing.T) {
 		},
 	})
 
-	require.True(t, dispatcher.DispatchAll([]event.Event{
+	require.NoError(t, dispatcher.DispatchAll([]event.Event{
 		testEvent{kind: "order.event", name: "first"},
 		testEvent{kind: "order.event", name: "second"},
 	}))
 	<-firstStarted
-	require.True(t, dispatcher.DispatchAll([]event.Event{
+	require.NoError(t, dispatcher.DispatchAll([]event.Event{
 		testEvent{kind: "order.event", name: "third"},
 	}))
 
@@ -535,9 +535,9 @@ func TestDispatcherCloseTimeoutStopsTakingQueuedBatches(t *testing.T) {
 		},
 	})
 
-	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.event", name: "first"}))
+	require.NoError(t, dispatcher.Dispatch(testEvent{kind: "order.event", name: "first"}))
 	<-firstStarted
-	require.True(t, dispatcher.Dispatch(testEvent{kind: "order.event", name: "second"}))
+	require.NoError(t, dispatcher.Dispatch(testEvent{kind: "order.event", name: "second"}))
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
 	defer cancel()

--- a/ddd/event/dispatcher_test.go
+++ b/ddd/event/dispatcher_test.go
@@ -35,6 +35,17 @@ func TestDispatcherInterfaceDoesNotRequireSubscription(t *testing.T) {
 	var _ event.Dispatcher = dispatchOnly{}
 }
 
+// Intent: the default constructor should return the concrete in-memory
+// component, not a generic bus abstraction.
+func TestNewDispatcherReturnsInMemoryDispatcher(t *testing.T) {
+	dispatcher := event.NewDispatcher(event.WithDelayClose(0))
+	defer dispatcher.Close(context.Background())
+
+	var _ *event.InMemoryDispatcher = dispatcher
+	var _ event.Dispatcher = dispatcher
+	var _ event.Subscriber = dispatcher
+}
+
 type logRecord struct {
 	level   slog.Level
 	message string

--- a/ddd/event/doc.go
+++ b/ddd/event/doc.go
@@ -1,11 +1,12 @@
 // Package event provides domain event primitives for use inside one bounded
-// context.
+// context. Concrete dispatchers may be in-memory or backed by external
+// middleware, but the package does not expose broker-specific concepts.
 //
-// The package is intentionally scoped to in-process domain events. It is not an
-// integration message bus, broker abstraction, transactional outbox, or reliable
-// delivery mechanism across process restarts.
+// The package is intentionally scoped to domain events inside one bounded
+// context. It is not an integration message bus, broker abstraction,
+// transactional outbox, or reliable delivery mechanism across process restarts.
 //
-// Dispatch only reports whether a batch was accepted by the dispatcher. It does
-// not report handler success or failure. Handlers represent follow-up
+// Dispatch errors report only dispatcher admission or delivery failures. They
+// do not report handler success or failure. Handlers represent follow-up
 // transactions and own their own error policy.
 package event

--- a/ddd/event/event.go
+++ b/ddd/event/event.go
@@ -1,6 +1,9 @@
 package event
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 // Kind identifies the kind of a domain event inside one bounded context.
 type Kind string
@@ -9,6 +12,10 @@ type Kind string
 type Event interface {
 	Kind() Kind
 }
+
+// ErrDispatcherClosed reports that a dispatcher cannot accept new events
+// because it is closing or closed.
+var ErrDispatcherClosed = errors.New("domain event dispatcher is closed")
 
 // UnhandledContext describes an event that has no registered handler.
 type UnhandledContext struct {
@@ -53,10 +60,10 @@ type Handler interface {
 	Handle(context.Context, Event)
 }
 
-// Dispatcher accepts domain event batches for in-process handling.
+// Dispatcher accepts domain event batches for handling.
 type Dispatcher interface {
 	Subscribe(Handler)
-	Dispatch(Event) bool
-	DispatchAll([]Event) bool
+	Dispatch(Event) error
+	DispatchAll([]Event) error
 	Close(context.Context) error
 }

--- a/ddd/event/event.go
+++ b/ddd/event/event.go
@@ -62,8 +62,18 @@ type Handler interface {
 
 // Dispatcher accepts domain event batches for handling.
 type Dispatcher interface {
-	Subscribe(Handler)
 	Dispatch(Event) error
 	DispatchAll([]Event) error
 	Close(context.Context) error
+}
+
+// Subscriber registers handlers for domain events.
+type Subscriber interface {
+	Subscribe(Handler)
+}
+
+// Bus combines dispatching and subscribing in one in-process component.
+type Bus interface {
+	Dispatcher
+	Subscriber
 }

--- a/ddd/event/event.go
+++ b/ddd/event/event.go
@@ -71,9 +71,3 @@ type Dispatcher interface {
 type Subscriber interface {
 	Subscribe(Handler)
 }
-
-// Bus combines dispatching and subscribing in one in-process component.
-type Bus interface {
-	Dispatcher
-	Subscriber
-}

--- a/ddd/event/option.go
+++ b/ddd/event/option.go
@@ -7,11 +7,11 @@ import (
 )
 
 // Option configures a Dispatcher during construction.
-type Option func(*dispatcher)
+type Option func(*InMemoryDispatcher)
 
 // WithLogger sets the logger for dispatcher lifecycle and runtime diagnostics.
 func WithLogger(logger *slog.Logger) Option {
-	return func(d *dispatcher) {
+	return func(d *InMemoryDispatcher) {
 		if logger != nil {
 			d.logger = logger
 		}
@@ -20,7 +20,7 @@ func WithLogger(logger *slog.Logger) Option {
 
 // WithDelayClose sets the delay before the dispatcher starts rejecting new events during shutdown.
 func WithDelayClose(delay time.Duration) Option {
-	return func(d *dispatcher) {
+	return func(d *InMemoryDispatcher) {
 		if delay >= 0 {
 			d.delayClose = delay
 		}
@@ -29,7 +29,7 @@ func WithDelayClose(delay time.Duration) Option {
 
 // WithHandlerTimeout sets the timeout for each handler invocation.
 func WithHandlerTimeout(timeout time.Duration) Option {
-	return func(d *dispatcher) {
+	return func(d *InMemoryDispatcher) {
 		if timeout >= 0 {
 			d.handlerTimeout = timeout
 		}
@@ -38,21 +38,21 @@ func WithHandlerTimeout(timeout time.Duration) Option {
 
 // WithContextFactory sets a function to derive a new context for each event dispatch.
 func WithContextFactory(fn func(context.Context, Event) context.Context) Option {
-	return func(d *dispatcher) {
+	return func(d *InMemoryDispatcher) {
 		d.contextFactory = fn
 	}
 }
 
 // WithUnhandledEventHandler sets a hook for events with no registered handler.
 func WithUnhandledEventHandler(fn func(UnhandledContext)) Option {
-	return func(d *dispatcher) {
+	return func(d *InMemoryDispatcher) {
 		d.unhandledEventHandler = fn
 	}
 }
 
 // WithPanicHandler sets a hook for recovered handler panics.
 func WithPanicHandler(fn func(PanicContext)) Option {
-	return func(d *dispatcher) {
+	return func(d *InMemoryDispatcher) {
 		d.panicHandler = fn
 	}
 }
@@ -60,14 +60,14 @@ func WithPanicHandler(fn func(PanicContext)) Option {
 // WithCloseInterruptedHandler sets a hook for close interruptions that leave
 // accepted work unconfirmed.
 func WithCloseInterruptedHandler(fn func(CloseInterruptedContext)) Option {
-	return func(d *dispatcher) {
+	return func(d *InMemoryDispatcher) {
 		d.closeInterruptedHandler = fn
 	}
 }
 
 // WithBufferSize sets the maximum number of queued event batches.
 func WithBufferSize(size int) Option {
-	return func(d *dispatcher) {
+	return func(d *InMemoryDispatcher) {
 		if size > 0 {
 			d.bufferSize = size
 		}

--- a/docs/mediator-migration.md
+++ b/docs/mediator-migration.md
@@ -8,8 +8,8 @@ be added to `ddd/event`.
 
 ## Key differences
 
-- `mediator.Dispatch` returns an `error`; `ddd/event.Dispatch` returns `bool`
-  and only reports whether a batch was accepted.
+- `mediator.Dispatch` returns legacy mediator errors; `ddd/event.Dispatch`
+  returns only dispatcher admission or delivery errors.
 - `ddd/event.Dispatch` does not accept caller context. Handler context is owned
   by the dispatcher because event handling is a follow-up transaction.
 - `ddd/event.Handler.Handle` does not return an error. Handlers own their own
@@ -17,9 +17,10 @@ be added to `ddd/event`.
 - `ddd/event.DispatchAll` preserves one aggregate transaction as one batch.
 - `ddd/event.Close` reports shutdown interruption through logs and an optional
   close-interrupted hook with pending batches.
-- `ddd/event` is only for in-process domain events inside one bounded context.
-  It is not an integration message bus, broker abstraction, outbox, retry
-  system, or reliable delivery mechanism across process restarts.
+- `ddd/event` is only for domain events inside one bounded context. Concrete
+  dispatchers may be in-memory or backed by external middleware, but the API
+  does not expose broker concepts and is not an integration message bus, outbox,
+  retry system, or reliable delivery mechanism across process restarts.
 
 ## Replacement guide
 

--- a/docs/mediator-migration.md
+++ b/docs/mediator-migration.md
@@ -12,6 +12,9 @@ be added to `ddd/event`.
   returns only dispatcher admission or delivery errors.
 - `ddd/event.Dispatch` does not accept caller context. Handler context is owned
   by the dispatcher because event handling is a follow-up transaction.
+- `ddd/event.Dispatcher` only covers dispatching. `ddd/event.Subscriber` covers
+  handler registration, and `event.NewDispatcher` returns a `Bus` that combines
+  both for the default in-memory implementation.
 - `ddd/event.Handler.Handle` does not return an error. Handlers own their own
   error policy.
 - `ddd/event.DispatchAll` preserves one aggregate transaction as one batch.

--- a/docs/mediator-migration.md
+++ b/docs/mediator-migration.md
@@ -13,8 +13,8 @@ be added to `ddd/event`.
 - `ddd/event.Dispatch` does not accept caller context. Handler context is owned
   by the dispatcher because event handling is a follow-up transaction.
 - `ddd/event.Dispatcher` only covers dispatching. `ddd/event.Subscriber` covers
-  handler registration, and `event.NewDispatcher` returns a `Bus` that combines
-  both for the default in-memory implementation.
+  handler registration, and `event.NewDispatcher` returns the default concrete
+  in-memory implementation that satisfies both interfaces.
 - `ddd/event.Handler.Handle` does not return an error. Handlers own their own
   error policy.
 - `ddd/event.DispatchAll` preserves one aggregate transaction as one batch.

--- a/docs/project-knowledge/architecture.md
+++ b/docs/project-knowledge/architecture.md
@@ -28,7 +28,7 @@ adds a DDD concept namespace under `ddd/`.
 - `fsm/` — finite state machine primitives and transition checks. Key abstractions: `State`, `StateContext`, `StateMachine`.
 - `logger/` and `sloghelper/` — logger adapters and helpers for `log/slog`.
 - `mediator/` — existing in-process event mediator with global default, event collection, subscription, dispatch, and graceful shutdown.
-- `ddd/event/` — DDD-oriented domain event collection, batch dispatch, and handler subscription. Key abstractions: `Event`, `Collection`, `Dispatcher`, `Subscriber`, `Bus`, `Handler`.
+- `ddd/event/` — DDD-oriented domain event collection, batch dispatch, and handler subscription. Key abstractions: `Event`, `Collection`, `Dispatcher`, `Subscriber`, `InMemoryDispatcher`, `Handler`.
 - `validation/` — notification and specification validation helpers.
 - `docs/superpowers/specs/` and `docs/superpowers/plans/` — design and implementation records for planned or recently completed work.
 

--- a/docs/project-knowledge/architecture.md
+++ b/docs/project-knowledge/architecture.md
@@ -12,7 +12,7 @@ This repository is a public Go component library. Packages are organized as
 small top-level capabilities instead of an application with service entry
 points, deployment manifests, or bounded-context folders.
 
-The current eventbus branch keeps the existing `mediator` package compatible and
+The current event branch keeps the existing `mediator` package compatible and
 adds a DDD concept namespace under `ddd/`.
 
 ## System Context
@@ -28,7 +28,7 @@ adds a DDD concept namespace under `ddd/`.
 - `fsm/` — finite state machine primitives and transition checks. Key abstractions: `State`, `StateContext`, `StateMachine`.
 - `logger/` and `sloghelper/` — logger adapters and helpers for `log/slog`.
 - `mediator/` — existing in-process event mediator with global default, event collection, subscription, dispatch, and graceful shutdown.
-- `ddd/event/` — DDD-oriented domain event collection and in-process batch dispatch. Key abstractions: `Event`, `Collection`, `Dispatcher`, `Handler`.
+- `ddd/event/` — DDD-oriented domain event collection and batch dispatch. Key abstractions: `Event`, `Collection`, `Dispatcher`, `Handler`.
 - `validation/` — notification and specification validation helpers.
 - `docs/superpowers/specs/` and `docs/superpowers/plans/` — design and implementation records for planned or recently completed work.
 
@@ -72,7 +72,7 @@ sequenceDiagram
     App->>App: Save aggregate
     App->>Collection: Drain()
     App->>Dispatcher: DispatchAll(events batch)
-    Dispatcher-->>App: accepted bool
+    Dispatcher-->>App: dispatch error or nil
 ```
 
 ## Key Object FSMs

--- a/docs/project-knowledge/architecture.md
+++ b/docs/project-knowledge/architecture.md
@@ -28,7 +28,7 @@ adds a DDD concept namespace under `ddd/`.
 - `fsm/` — finite state machine primitives and transition checks. Key abstractions: `State`, `StateContext`, `StateMachine`.
 - `logger/` and `sloghelper/` — logger adapters and helpers for `log/slog`.
 - `mediator/` — existing in-process event mediator with global default, event collection, subscription, dispatch, and graceful shutdown.
-- `ddd/event/` — DDD-oriented domain event collection and batch dispatch. Key abstractions: `Event`, `Collection`, `Dispatcher`, `Handler`.
+- `ddd/event/` — DDD-oriented domain event collection, batch dispatch, and handler subscription. Key abstractions: `Event`, `Collection`, `Dispatcher`, `Subscriber`, `Bus`, `Handler`.
 - `validation/` — notification and specification validation helpers.
 - `docs/superpowers/specs/` and `docs/superpowers/plans/` — design and implementation records for planned or recently completed work.
 

--- a/docs/project-knowledge/features.md
+++ b/docs/project-knowledge/features.md
@@ -55,18 +55,18 @@ triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 
 ### DDD Event
 
-#### Domain event collection and in-process dispatch
+#### Domain event collection and dispatch
 
 - Enables: DDD-style services collect domain events inside one bounded context and submit event batches after persistence.
 - Actors / Entry Points: domain aggregates use `ddd/event.Collection`; application services use `ddd/event.Dispatcher`.
-- Capability Boundary: single-process domain events only; no integration message bus, broker, retry, or outbox.
+- Capability Boundary: domain events inside one bounded context only; dispatch errors mean admission or delivery failure, not handler business failure.
 - References: `ddd/event/`, `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 
 #### Dispatcher runtime diagnostics
 
 - Enables: dispatcher owners trace runtime dispatch health and shutdown interruptions.
 - Actors / Entry Points: application services configure `ddd/event.Dispatcher` options and consume logs or runtime hooks.
-- Capability Boundary: diagnostics for in-process domain event dispatch only; forced shutdown pending events are best-effort offline compensation clues, not a durable event audit log.
+- Capability Boundary: diagnostics for domain event dispatch only; forced shutdown pending events are best-effort offline compensation clues, not a durable event audit log.
 - References: `ddd/event/`, `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 
 ### Validation

--- a/docs/project-knowledge/features.md
+++ b/docs/project-knowledge/features.md
@@ -58,7 +58,7 @@ triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 #### Domain event collection and dispatch
 
 - Enables: services collect and submit domain event batches after persistence.
-- Actors / Entry Points: domain aggregates use `ddd/event.Collection`; application services use `ddd/event.Dispatcher`, `Subscriber`, or `Bus`.
+- Actors / Entry Points: domain aggregates use `ddd/event.Collection`; application services use `ddd/event.Dispatcher`, `Subscriber`, or `InMemoryDispatcher`.
 - Capability Boundary: domain events inside one bounded context only; dispatch errors mean admission or delivery failure, not handler business failure.
 - References: `ddd/event/`, `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 

--- a/docs/project-knowledge/features.md
+++ b/docs/project-knowledge/features.md
@@ -57,8 +57,8 @@ triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 
 #### Domain event collection and dispatch
 
-- Enables: DDD-style services collect domain events inside one bounded context and submit event batches after persistence.
-- Actors / Entry Points: domain aggregates use `ddd/event.Collection`; application services use `ddd/event.Dispatcher`.
+- Enables: services collect and submit domain event batches after persistence.
+- Actors / Entry Points: domain aggregates use `ddd/event.Collection`; application services use `ddd/event.Dispatcher`, `Subscriber`, or `Bus`.
 - Capability Boundary: domain events inside one bounded context only; dispatch errors mean admission or delivery failure, not handler business failure.
 - References: `ddd/event/`, `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 

--- a/docs/project-knowledge/glossary.md
+++ b/docs/project-knowledge/glossary.md
@@ -12,7 +12,7 @@ triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 
 **Event Collection** — A per-aggregate holder for undrained domain events. → `ddd/event/`
 
-**Dispatcher** — Domain event batch admission interface; `Subscriber` registers handlers and `Bus` combines both. → `ddd/event/`
+**Dispatcher** — Domain event batch admission interface; `Subscriber` registers handlers. → `ddd/event/`
 
 **BatchID** — Dispatcher-local diagnostic identifier assigned to each accepted `ddd/event` batch. → `ddd/event/`
 

--- a/docs/project-knowledge/glossary.md
+++ b/docs/project-knowledge/glossary.md
@@ -12,7 +12,7 @@ triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 
 **Event Collection** — A per-aggregate holder for undrained domain events. → `ddd/event/`
 
-**Dispatcher** — In-process batch admission and handler execution component for `ddd/event`. → `ddd/event/`
+**Dispatcher** — Domain event batch admission and handler execution component for `ddd/event`. → `ddd/event/`
 
 **BatchID** — Dispatcher-local diagnostic identifier assigned to each accepted `ddd/event` batch. → `ddd/event/`
 

--- a/docs/project-knowledge/glossary.md
+++ b/docs/project-knowledge/glossary.md
@@ -12,7 +12,7 @@ triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 
 **Event Collection** — A per-aggregate holder for undrained domain events. → `ddd/event/`
 
-**Dispatcher** — Domain event batch admission and handler execution component for `ddd/event`. → `ddd/event/`
+**Dispatcher** — Domain event batch admission interface; `Subscriber` registers handlers and `Bus` combines both. → `ddd/event/`
 
 **BatchID** — Dispatcher-local diagnostic identifier assigned to each accepted `ddd/event` batch. → `ddd/event/`
 

--- a/docs/project-knowledge/index.md
+++ b/docs/project-knowledge/index.md
@@ -12,4 +12,4 @@ covers_branch: hotfix/event@7ffd84d
 - `tech-stack.md` — Go 1.24 module, CI matrix 1.23/1.24/1.25, core dependencies and Make targets.
 - `conventions.md` — package style, tests with `go test -race -covermode=atomic`, CI/benchmark workflow.
 - `decisions.md` — design decision summary for preserving `mediator` and adding `ddd/event`.
-- `glossary.md` — project terms including legacy mediator, domain event, event collection, dispatcher/subscriber/bus, BatchID, abandoned batch, integration message, and outbox.
+- `glossary.md` — project terms including legacy mediator, domain event, event collection, dispatcher/subscriber, BatchID, abandoned batch, integration message, and outbox.

--- a/docs/project-knowledge/index.md
+++ b/docs/project-knowledge/index.md
@@ -2,14 +2,14 @@
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
 triggered_by_plan: 2026-05-10-ddd-event-implementation.md
-covers_branch: hotfix/event@7ffd84d
+covers_branch: hotfix/event@d685f59
 ---
 
 # Project Knowledge Index
 
 - `architecture.md` — top-level Go component layout including the new `ddd/event` DDD concept package.
-- `features.md` — current capabilities including legacy `mediator`, `ddd/event` collection, dispatch/subscription split, and diagnostics.
+- `features.md` — current capabilities including legacy `mediator`, `ddd/event` collection, split dispatcher/subscriber APIs, in-memory dispatcher, and diagnostics.
 - `tech-stack.md` — Go 1.24 module, CI matrix 1.23/1.24/1.25, core dependencies and Make targets.
 - `conventions.md` — package style, tests with `go test -race -covermode=atomic`, CI/benchmark workflow.
 - `decisions.md` — design decision summary for preserving `mediator` and adding `ddd/event`.
-- `glossary.md` — project terms including legacy mediator, domain event, event collection, dispatcher/subscriber, BatchID, abandoned batch, integration message, and outbox.
+- `glossary.md` — project terms including legacy mediator, domain event, event collection, dispatcher/subscriber, in-memory dispatcher diagnostics, integration message, and outbox.

--- a/docs/project-knowledge/index.md
+++ b/docs/project-knowledge/index.md
@@ -2,14 +2,14 @@
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
 triggered_by_plan: 2026-05-10-ddd-event-implementation.md
-covers_branch: hotfix/event@e89b15e
+covers_branch: hotfix/event@7ffd84d
 ---
 
 # Project Knowledge Index
 
 - `architecture.md` — top-level Go component layout including the new `ddd/event` DDD concept package.
-- `features.md` — current capabilities including legacy `mediator`, `ddd/event` collection, dispatch errors, and diagnostics.
+- `features.md` — current capabilities including legacy `mediator`, `ddd/event` collection, dispatch/subscription split, and diagnostics.
 - `tech-stack.md` — Go 1.24 module, CI matrix 1.23/1.24/1.25, core dependencies and Make targets.
 - `conventions.md` — package style, tests with `go test -race -covermode=atomic`, CI/benchmark workflow.
 - `decisions.md` — design decision summary for preserving `mediator` and adding `ddd/event`.
-- `glossary.md` — project terms including legacy mediator, domain event, event collection, dispatcher, BatchID, abandoned batch, integration message, and outbox.
+- `glossary.md` — project terms including legacy mediator, domain event, event collection, dispatcher/subscriber/bus, BatchID, abandoned batch, integration message, and outbox.

--- a/docs/project-knowledge/index.md
+++ b/docs/project-knowledge/index.md
@@ -2,13 +2,13 @@
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
 triggered_by_plan: 2026-05-10-ddd-event-implementation.md
-covers_branch: hotfix/eventbus@2232cc0
+covers_branch: hotfix/event@e89b15e
 ---
 
 # Project Knowledge Index
 
 - `architecture.md` — top-level Go component layout including the new `ddd/event` DDD concept package.
-- `features.md` — current capabilities including legacy `mediator`, `ddd/event` collection, in-process dispatch, and diagnostics.
+- `features.md` — current capabilities including legacy `mediator`, `ddd/event` collection, dispatch errors, and diagnostics.
 - `tech-stack.md` — Go 1.24 module, CI matrix 1.23/1.24/1.25, core dependencies and Make targets.
 - `conventions.md` — package style, tests with `go test -race -covermode=atomic`, CI/benchmark workflow.
 - `decisions.md` — design decision summary for preserving `mediator` and adding `ddd/event`.

--- a/docs/superpowers/specs/2026-05-10-ddd-event-design.md
+++ b/docs/superpowers/specs/2026-05-10-ddd-event-design.md
@@ -124,19 +124,32 @@ type Handler interface {
 }
 
 type Dispatcher interface {
-    Subscribe(Handler)
     Dispatch(Event) error
     DispatchAll([]Event) error
     Close(context.Context) error
 }
 
+type Subscriber interface {
+    Subscribe(Handler)
+}
+
+type Bus interface {
+    Dispatcher
+    Subscriber
+}
+
 func NewCollection() Collection
-func NewDispatcher(opts ...Option) Dispatcher
+func NewDispatcher(opts ...Option) Bus
 ```
 
 `Handler.Handle` does not return an error. A handler represents a follow-up
 transaction or reaction. The previous application transaction does not observe
 the handler's result through `Dispatch`.
+
+`Dispatcher` and `Subscriber` are separate interfaces so producer-only
+implementations, such as an MQ-backed dispatcher, do not need to expose handler
+registration. The default in-memory component is a `Bus`, which combines both
+interfaces.
 
 `Dispatch` does not accept caller context. The caller's context usually belongs
 to the current synchronous request or command. Event handling is a later

--- a/docs/superpowers/specs/2026-05-10-ddd-event-design.md
+++ b/docs/superpowers/specs/2026-05-10-ddd-event-design.md
@@ -133,13 +133,12 @@ type Subscriber interface {
     Subscribe(Handler)
 }
 
-type Bus interface {
-    Dispatcher
-    Subscriber
+type InMemoryDispatcher struct {
+    // unexported fields
 }
 
 func NewCollection() Collection
-func NewDispatcher(opts ...Option) Bus
+func NewDispatcher(opts ...Option) *InMemoryDispatcher
 ```
 
 `Handler.Handle` does not return an error. A handler represents a follow-up
@@ -148,8 +147,10 @@ the handler's result through `Dispatch`.
 
 `Dispatcher` and `Subscriber` are separate interfaces so producer-only
 implementations, such as an MQ-backed dispatcher, do not need to expose handler
-registration. The default in-memory component is a `Bus`, which combines both
-interfaces.
+registration. `Bus` is intentionally not a shared API concept because dispatch
+and subscription often belong to different processes once a third-party MQ is
+involved. The default in-memory component is a concrete `InMemoryDispatcher`
+that implements both interfaces.
 
 `Dispatch` does not accept caller context. The caller's context usually belongs
 to the current synchronous request or command. Event handling is a later

--- a/docs/superpowers/specs/2026-05-10-ddd-event-design.md
+++ b/docs/superpowers/specs/2026-05-10-ddd-event-design.md
@@ -8,7 +8,9 @@ Status: Draft for review
 Add a new DDD-oriented domain event module without changing the existing
 `mediator` package. The existing `mediator` API remains compatible for current
 users. The new module provides a cleaner boundary for domain event collection
-and in-process dispatch inside one bounded context.
+and dispatch inside one bounded context. The default dispatcher is in-process,
+but the interface may also be implemented with an external backing mechanism
+without exposing broker-specific concepts.
 
 The first module is:
 
@@ -40,15 +42,19 @@ It is not:
 Cross bounded-context or cross-service contracts belong in a future
 `ddd/message` package. Outbox reliability belongs under `ddd/message/outbox`.
 
+A concrete `Dispatcher` may use a third-party MQ as its backing mechanism while
+preserving domain-event semantics. The API must not expose Kafka topics,
+partitions, offsets, acknowledgements, or broker-specific retry policy.
+
 ## Architecture Gate
 
 - Gate level: Level 3, because this introduces a new DDD concept package and a
   new event dispatch boundary.
 - Bounded context / business capability: shared component library capability for
-  domain event collection and in-process dispatch.
+  domain event collection and dispatch inside one bounded context.
 - Stable language / data authority: `Event` is an internal domain fact in one
   bounded context. `Collection` records facts raised by an aggregate.
-  `Dispatcher` accepts event batches for in-process handling.
+  `Dispatcher` accepts event batches for domain event handling.
 - Affected aggregate, policy, or service: no business aggregate. Affects shared
   event collection, event dispatch, handler subscription, and shutdown policy.
 - Invariants and rules: domain methods collect events only; application drains
@@ -70,13 +76,18 @@ Proposed package:
 ```go
 package event
 
-import "context"
+import (
+    "context"
+    "errors"
+)
 
 type Kind string
 
 type Event interface {
     Kind() Kind
 }
+
+var ErrDispatcherClosed = errors.New("domain event dispatcher is closed")
 
 type UnhandledContext struct {
     BatchID uint64
@@ -114,8 +125,8 @@ type Handler interface {
 
 type Dispatcher interface {
     Subscribe(Handler)
-    Dispatch(Event) bool
-    DispatchAll([]Event) bool
+    Dispatch(Event) error
+    DispatchAll([]Event) error
     Close(context.Context) error
 }
 
@@ -192,10 +203,10 @@ explicit application service step or domain rule, not a domain event handler.
 
 `Dispatch` and `DispatchAll` are admission APIs.
 
-- `true` means the dispatcher accepted the event batch.
-- `false` means the dispatcher is closing or closed and did not accept the
-  batch.
-- The return value does not report handler success or failure.
+- `nil` means the dispatcher accepted the event batch.
+- a non-nil error means the dispatcher did not accept the batch because of an
+  admission or delivery failure.
+- Dispatch errors do not report handler success or failure.
 
 `Dispatch(event)` is equivalent to submitting one batch containing one event.
 
@@ -203,7 +214,21 @@ explicit application service step or domain rule, not a domain event handler.
 independent `Dispatch` calls because other batches could interleave between
 events from the same aggregate transaction.
 
-Empty batches return `true` and do not enqueue work.
+Empty batches return `nil` and do not enqueue work.
+
+Dispatch errors are limited to dispatcher/backing-mechanism failures, for
+example a closed dispatcher, forced shutdown, internal admission failure,
+serialization failure in a concrete implementation, or third-party MQ
+communication failure in an MQ-backed implementation. Handler business failures
+are not returned by `Dispatch`; handlers own their own failure recording, retry,
+compensation, and alerting policy.
+
+For MQ-backed implementations, a broker publish or communication failure is a
+dispatch error and should be returned to the caller. Handler business failures
+are different: they happen after the event has been handed to the handling
+mechanism, and the handler owns its own compensation or retry record. MQ commit
+or acknowledgement semantics in such an implementation must mean successful
+handoff to the domain event handling mechanism, not business success.
 
 ## Ordering
 
@@ -267,19 +292,19 @@ type batch struct {
 
 When open:
 
-- `Dispatch` and `DispatchAll` enqueue a batch and return `true`.
+- `Dispatch` and `DispatchAll` enqueue a batch and return `nil`.
 - If the buffer is full, dispatch waits for space.
 
 When closing or closed:
 
-- new dispatch calls return `false`.
+- new dispatch calls return `ErrDispatcherClosed`.
 - already accepted batches continue to drain.
 - `Close(ctx)` waits for accepted batches to finish or returns `ctx.Err()`.
 
 If `Close(ctx)` is interrupted before accepted batches finish, the dispatcher
 enters a forced shutdown state:
 
-- new dispatch calls still return `false`.
+- new dispatch calls still return `ErrDispatcherClosed`.
 - the current handler context is canceled through the dispatcher root context.
 - the worker stops taking additional queued batches.
 - remaining queued batches are considered abandoned in memory.
@@ -355,9 +380,9 @@ Collection tests:
 
 Dispatcher admission tests:
 
-- `Dispatch` and `DispatchAll` return `true` while open
-- `Dispatch` and `DispatchAll` return `false` after close starts
-- empty batch returns `true`
+- `Dispatch` and `DispatchAll` return `nil` while open
+- `Dispatch` and `DispatchAll` return `ErrDispatcherClosed` after close starts
+- empty batch returns `nil`
 - `Dispatch` behaves as a single-event batch
 
 Ordering tests:
@@ -393,8 +418,8 @@ It does not provide reliable delivery across process restarts.
 ```
 
 ```text
-Dispatch only reports whether a batch was accepted.
-It does not report handler success or failure.
+Dispatch errors report only dispatcher admission or delivery failures.
+They do not report handler success or failure.
 Handlers represent follow-up transactions and own their own error policy.
 ```
 


### PR DESCRIPTION
## Summary
- Change `ddd/event.Dispatcher` dispatch methods to return dispatch errors, including `ErrDispatcherClosed`, so admission or delivery failures are explicit.
- Split dispatching and subscription responsibilities into `Dispatcher` and `Subscriber`; the default in-memory implementation is exposed as `InMemoryDispatcher` through `NewDispatcher`.
- Document the domain event boundary for MQ-backed implementations: dispatch errors are infrastructure/admission failures, while handler business failures are owned by handlers and are not returned by dispatch.

## Test Plan
- `go test -race ./... -count=1`
- `go doc ./ddd/event`
- `superpowers-memory verify`