### PR TITLE
feat: add protobuf integration message abstraction

### DIFF
--- a/ddd/message/doc.go
+++ b/ddd/message/doc.go
@@ -1,0 +1,8 @@
+// Package message provides protobuf-first integration message primitives for
+// direct, non-transactional communication across boundaries.
+//
+// The package is separate from ddd/event. Domain events model facts raised
+// inside a bounded context and are usually dispatched after persistence.
+// Integration messages in this package wrap protobuf payloads with routing and
+// trace metadata for direct publication without transactional guarantees.
+package message

--- a/ddd/message/errors.go
+++ b/ddd/message/errors.go
@@ -1,0 +1,12 @@
+package message
+
+import "errors"
+
+var (
+	ErrEmptyKind     = errors.New("message kind is empty")
+	ErrNilPayload    = errors.New("message payload is nil")
+	ErrEmptyID       = errors.New("message id is empty")
+	ErrNilHandler    = errors.New("message handler is nil")
+	ErrNoListening   = errors.New("message handler listens to no kinds")
+	ErrUnhandledKind = errors.New("message kind is unhandled")
+)

--- a/ddd/message/message.go
+++ b/ddd/message/message.go
@@ -1,0 +1,110 @@
+package message
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+)
+
+type Kind string
+
+type Message struct {
+	id         string
+	kind       Kind
+	key        string
+	occurredAt time.Time
+	payload    proto.Message
+	headers    map[string]string
+}
+
+func New(kind Kind, payload proto.Message, opts ...Option) (Message, error) {
+	if kind == "" {
+		return Message{}, ErrEmptyKind
+	}
+	if payload == nil {
+		return Message{}, ErrNilPayload
+	}
+
+	cfg := messageConfig{}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.idSet && cfg.id == "" {
+		return Message{}, ErrEmptyID
+	}
+
+	id := cfg.id
+	if id == "" {
+		generated, err := generateID()
+		if err != nil {
+			return Message{}, err
+		}
+		id = generated
+	}
+
+	occurredAt := cfg.occurredAt
+	if occurredAt.IsZero() {
+		occurredAt = time.Now()
+	}
+
+	return Message{
+		id:         id,
+		kind:       kind,
+		key:        cfg.key,
+		occurredAt: occurredAt,
+		payload:    payload,
+		headers:    cloneHeaders(cfg.headers),
+	}, nil
+}
+
+func (m Message) ID() string {
+	return m.id
+}
+
+func (m Message) Kind() Kind {
+	return m.kind
+}
+
+func (m Message) Key() string {
+	return m.key
+}
+
+func (m Message) OccurredAt() time.Time {
+	return m.occurredAt
+}
+
+func (m Message) Payload() proto.Message {
+	return m.payload
+}
+
+func (m Message) Headers() map[string]string {
+	return cloneHeaders(m.headers)
+}
+
+func KindOf(payload proto.Message) Kind {
+	if payload == nil {
+		return ""
+	}
+	return Kind(payload.ProtoReflect().Descriptor().FullName())
+}
+
+func generateID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+
+func cloneHeaders(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(headers))
+	for k, v := range headers {
+		copied[k] = v
+	}
+	return copied
+}

--- a/ddd/message/message.go
+++ b/ddd/message/message.go
@@ -3,6 +3,7 @@ package message
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"reflect"
 	"time"
 
 	"google.golang.org/protobuf/proto"
@@ -23,13 +24,15 @@ func New(kind Kind, payload proto.Message, opts ...Option) (Message, error) {
 	if kind == "" {
 		return Message{}, ErrEmptyKind
 	}
-	if payload == nil {
+	if isNilPayload(payload) {
 		return Message{}, ErrNilPayload
 	}
 
 	cfg := messageConfig{}
 	for _, opt := range opts {
-		opt(&cfg)
+		if opt != nil {
+			opt(&cfg)
+		}
 	}
 	if cfg.idSet && cfg.id == "" {
 		return Message{}, ErrEmptyID
@@ -84,10 +87,24 @@ func (m Message) Headers() map[string]string {
 }
 
 func KindOf(payload proto.Message) Kind {
-	if payload == nil {
+	if isNilPayload(payload) {
 		return ""
 	}
 	return Kind(payload.ProtoReflect().Descriptor().FullName())
+}
+
+func isNilPayload(payload proto.Message) bool {
+	if payload == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(payload)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }
 
 func generateID() (string, error) {

--- a/ddd/message/message_test.go
+++ b/ddd/message/message_test.go
@@ -26,6 +26,16 @@ func TestNewRejectsNilPayload(t *testing.T) {
 	require.Equal(t, message.Message{}, msg)
 }
 
+// Typed-nil protobuf payloads must be rejected so nil pointers cannot masquerade as valid message contracts.
+func TestNewRejectsTypedNilPayload(t *testing.T) {
+	var payload *testdata.TestModel
+
+	msg, err := message.New("test.TestModel", payload)
+
+	require.True(t, errors.Is(err, message.ErrNilPayload))
+	require.Equal(t, message.Message{}, msg)
+}
+
 // Required inputs should produce a valid message with generated metadata and the original protobuf payload.
 func TestNewDefaultsIDAndOccurredAt(t *testing.T) {
 	payload := &testdata.TestModel{}
@@ -42,6 +52,14 @@ func TestNewDefaultsIDAndOccurredAt(t *testing.T) {
 	require.False(t, msg.OccurredAt().Before(before))
 	require.False(t, msg.OccurredAt().After(after))
 	require.Empty(t, msg.Headers())
+}
+
+// Nil options should be ignored so callers can pass optional construction hooks without panicking.
+func TestNewIgnoresNilOption(t *testing.T) {
+	msg, err := message.New("test.TestModel", &testdata.TestModel{}, nil)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, msg.ID())
 }
 
 // Explicit metadata options should be reflected by accessors so publishers can preserve routing and tracing context.

--- a/ddd/message/message_test.go
+++ b/ddd/message/message_test.go
@@ -1,0 +1,111 @@
+package message_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message"
+	testdata "github.com/go-jimu/components/encoding/testdata"
+	"github.com/stretchr/testify/require"
+)
+
+// Empty message kinds must be rejected so integration messages always have a routable contract name.
+func TestNewRejectsEmptyKind(t *testing.T) {
+	msg, err := message.New("", &testdata.TestModel{})
+
+	require.True(t, errors.Is(err, message.ErrEmptyKind))
+	require.Equal(t, message.Message{}, msg)
+}
+
+// Nil payloads must be rejected so every integration message carries a protobuf contract.
+func TestNewRejectsNilPayload(t *testing.T) {
+	msg, err := message.New("test.TestModel", nil)
+
+	require.True(t, errors.Is(err, message.ErrNilPayload))
+	require.Equal(t, message.Message{}, msg)
+}
+
+// Required inputs should produce a valid message with generated metadata and the original protobuf payload.
+func TestNewDefaultsIDAndOccurredAt(t *testing.T) {
+	payload := &testdata.TestModel{}
+	before := time.Now()
+
+	msg, err := message.New("test.TestModel", payload)
+
+	after := time.Now()
+	require.NoError(t, err)
+	require.NotEmpty(t, msg.ID())
+	require.Equal(t, message.Kind("test.TestModel"), msg.Kind())
+	require.Empty(t, msg.Key())
+	require.Same(t, payload, msg.Payload())
+	require.False(t, msg.OccurredAt().Before(before))
+	require.False(t, msg.OccurredAt().After(after))
+	require.Empty(t, msg.Headers())
+}
+
+// Explicit metadata options should be reflected by accessors so publishers can preserve routing and tracing context.
+func TestNewAppliesExplicitMetadata(t *testing.T) {
+	payload := &testdata.TestModel{}
+	occurredAt := time.Date(2026, 5, 10, 12, 30, 0, 0, time.UTC)
+
+	msg, err := message.New(
+		"test.TestModel",
+		payload,
+		message.WithID("msg-1"),
+		message.WithKey("order-7"),
+		message.WithOccurredAt(occurredAt),
+		message.WithHeader("trace_id", "trace-1"),
+		message.WithHeaders(map[string]string{"tenant": "tenant-a"}),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "msg-1", msg.ID())
+	require.Equal(t, message.Kind("test.TestModel"), msg.Kind())
+	require.Equal(t, "order-7", msg.Key())
+	require.Equal(t, occurredAt, msg.OccurredAt())
+	require.Same(t, payload, msg.Payload())
+	require.Equal(t, map[string]string{
+		"trace_id": "trace-1",
+		"tenant":   "tenant-a",
+	}, msg.Headers())
+}
+
+// Explicit empty IDs must be rejected instead of silently generating a replacement.
+func TestNewRejectsExplicitEmptyID(t *testing.T) {
+	msg, err := message.New("test.TestModel", &testdata.TestModel{}, message.WithID(""))
+
+	require.True(t, errors.Is(err, message.ErrEmptyID))
+	require.Equal(t, message.Message{}, msg)
+}
+
+// Header maps passed to options must be copied so callers cannot mutate message metadata after construction.
+func TestNewCopiesHeadersOnInput(t *testing.T) {
+	headers := map[string]string{"tenant": "tenant-a"}
+
+	msg, err := message.New("test.TestModel", &testdata.TestModel{}, message.WithHeaders(headers))
+	require.NoError(t, err)
+
+	headers["tenant"] = "tenant-b"
+	headers["trace_id"] = "trace-1"
+
+	require.Equal(t, map[string]string{"tenant": "tenant-a"}, msg.Headers())
+}
+
+// Headers must return a copy so callers cannot mutate message metadata through the accessor.
+func TestHeadersReturnsCopy(t *testing.T) {
+	msg, err := message.New("test.TestModel", &testdata.TestModel{}, message.WithHeader("tenant", "tenant-a"))
+	require.NoError(t, err)
+
+	headers := msg.Headers()
+	headers["tenant"] = "tenant-b"
+	headers["trace_id"] = "trace-1"
+
+	require.Equal(t, map[string]string{"tenant": "tenant-a"}, msg.Headers())
+}
+
+// KindOf should derive the protobuf full name and return an empty kind for absent payloads.
+func TestKindOf(t *testing.T) {
+	require.Equal(t, message.Kind("test.test_model"), message.KindOf(&testdata.TestModel{}))
+	require.Empty(t, message.KindOf(nil))
+}

--- a/ddd/message/option.go
+++ b/ddd/message/option.go
@@ -1,0 +1,55 @@
+package message
+
+import "time"
+
+type Option func(*messageConfig)
+
+type messageConfig struct {
+	id         string
+	idSet      bool
+	key        string
+	occurredAt time.Time
+	headers    map[string]string
+}
+
+func WithID(id string) Option {
+	return func(cfg *messageConfig) {
+		cfg.id = id
+		cfg.idSet = true
+	}
+}
+
+func WithKey(key string) Option {
+	return func(cfg *messageConfig) {
+		cfg.key = key
+	}
+}
+
+func WithOccurredAt(occurredAt time.Time) Option {
+	return func(cfg *messageConfig) {
+		cfg.occurredAt = occurredAt
+	}
+}
+
+func WithHeader(key, value string) Option {
+	return func(cfg *messageConfig) {
+		if cfg.headers == nil {
+			cfg.headers = make(map[string]string)
+		}
+		cfg.headers[key] = value
+	}
+}
+
+func WithHeaders(headers map[string]string) Option {
+	return func(cfg *messageConfig) {
+		if len(headers) == 0 {
+			return
+		}
+		if cfg.headers == nil {
+			cfg.headers = make(map[string]string, len(headers))
+		}
+		for key, value := range headers {
+			cfg.headers[key] = value
+		}
+	}
+}

--- a/ddd/message/router.go
+++ b/ddd/message/router.go
@@ -1,0 +1,68 @@
+package message
+
+import (
+	"context"
+	"sync"
+)
+
+type Publisher interface {
+	Publish(context.Context, Message) error
+}
+
+type Handler interface {
+	Listening() []Kind
+	Handle(context.Context, Message) error
+}
+
+type Subscriber interface {
+	Subscribe(Handler) error
+}
+
+type Router struct {
+	mu       sync.RWMutex
+	handlers map[Kind][]Handler
+}
+
+var _ Subscriber = (*Router)(nil)
+
+func NewRouter() *Router {
+	return &Router{
+		handlers: make(map[Kind][]Handler),
+	}
+}
+
+func (r *Router) Subscribe(handler Handler) error {
+	if handler == nil {
+		return ErrNilHandler
+	}
+
+	kinds := handler.Listening()
+	if len(kinds) == 0 {
+		return ErrNoListening
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, kind := range kinds {
+		r.handlers[kind] = append(r.handlers[kind], handler)
+	}
+	return nil
+}
+
+func (r *Router) Handle(ctx context.Context, msg Message) error {
+	r.mu.RLock()
+	handlers := append([]Handler(nil), r.handlers[msg.Kind()]...)
+	r.mu.RUnlock()
+
+	if len(handlers) == 0 {
+		return ErrUnhandledKind
+	}
+
+	for _, handler := range handlers {
+		if err := handler.Handle(ctx, msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/ddd/message/router.go
+++ b/ddd/message/router.go
@@ -41,10 +41,23 @@ func (r *Router) Subscribe(handler Handler) error {
 		return ErrNoListening
 	}
 
+	seen := make(map[Kind]struct{}, len(kinds))
+	deduped := make([]Kind, 0, len(kinds))
+	for _, kind := range kinds {
+		if kind == "" {
+			return ErrEmptyKind
+		}
+		if _, ok := seen[kind]; ok {
+			continue
+		}
+		seen[kind] = struct{}{}
+		deduped = append(deduped, kind)
+	}
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
-	for _, kind := range kinds {
+	for _, kind := range deduped {
 		r.handlers[kind] = append(r.handlers[kind], handler)
 	}
 	return nil

--- a/ddd/message/router_test.go
+++ b/ddd/message/router_test.go
@@ -1,0 +1,143 @@
+package message_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-jimu/components/ddd/message"
+	testdata "github.com/go-jimu/components/encoding/testdata"
+	"github.com/stretchr/testify/require"
+)
+
+type handlerFunc struct {
+	kinds  []message.Kind
+	handle func(context.Context, message.Message) error
+}
+
+func (h handlerFunc) Listening() []message.Kind {
+	return h.kinds
+}
+
+func (h handlerFunc) Handle(ctx context.Context, msg message.Message) error {
+	if h.handle == nil {
+		return nil
+	}
+	return h.handle(ctx, msg)
+}
+
+func newTestMessage(t *testing.T, kind message.Kind) message.Message {
+	t.Helper()
+
+	msg, err := message.New(kind, &testdata.TestModel{Id: 1})
+	require.NoError(t, err)
+	return msg
+}
+
+// Intent: broker adapters should be able to depend on the Subscriber
+// capability without knowing the concrete router type.
+func TestRouterImplementsSubscriber(t *testing.T) {
+	var _ message.Subscriber = message.NewRouter()
+}
+
+// Intent: registering a nil handler should fail before a consumer silently
+// drops all messages for a kind.
+func TestRouterSubscribeRejectsNilHandler(t *testing.T) {
+	router := message.NewRouter()
+
+	require.ErrorIs(t, router.Subscribe(nil), message.ErrNilHandler)
+}
+
+// Intent: a handler that listens to no kinds cannot be matched and should be
+// rejected during subscription.
+func TestRouterSubscribeRejectsNoListening(t *testing.T) {
+	router := message.NewRouter()
+
+	require.ErrorIs(t, router.Subscribe(handlerFunc{}), message.ErrNoListening)
+}
+
+// Intent: an integration message without a matching handler should surface as
+// an error so the broker adapter can choose nack, retry, or failure recording.
+func TestRouterHandleUnhandledKind(t *testing.T) {
+	router := message.NewRouter()
+	msg := newTestMessage(t, "test.TestModel")
+
+	require.ErrorIs(t, router.Handle(context.Background(), msg), message.ErrUnhandledKind)
+}
+
+// Intent: matching handlers should run in subscription order to keep direct
+// in-process routing deterministic.
+func TestRouterHandleCallsMatchingHandlersInSubscriptionOrder(t *testing.T) {
+	router := message.NewRouter()
+	seen := make([]string, 0, 2)
+
+	require.NoError(t, router.Subscribe(handlerFunc{
+		kinds: []message.Kind{"test.TestModel"},
+		handle: func(context.Context, message.Message) error {
+			seen = append(seen, "first")
+			return nil
+		},
+	}))
+	require.NoError(t, router.Subscribe(handlerFunc{
+		kinds: []message.Kind{"test.TestModel"},
+		handle: func(context.Context, message.Message) error {
+			seen = append(seen, "second")
+			return nil
+		},
+	}))
+
+	require.NoError(t, router.Handle(context.Background(), newTestMessage(t, "test.TestModel")))
+	require.Equal(t, []string{"first", "second"}, seen)
+}
+
+// Intent: handlers for unrelated integration message kinds must not receive a
+// message just because they share the same router.
+func TestRouterHandleSkipsOtherKinds(t *testing.T) {
+	router := message.NewRouter()
+	seen := make([]string, 0, 1)
+
+	require.NoError(t, router.Subscribe(handlerFunc{
+		kinds: []message.Kind{"other.Kind"},
+		handle: func(context.Context, message.Message) error {
+			seen = append(seen, "other")
+			return nil
+		},
+	}))
+	require.NoError(t, router.Subscribe(handlerFunc{
+		kinds: []message.Kind{"test.TestModel"},
+		handle: func(context.Context, message.Message) error {
+			seen = append(seen, "target")
+			return nil
+		},
+	}))
+
+	require.NoError(t, router.Handle(context.Background(), newTestMessage(t, "test.TestModel")))
+	require.Equal(t, []string{"target"}, seen)
+}
+
+// Intent: when a handler fails, the router should stop so a broker adapter can
+// avoid acknowledging a partially handled message.
+func TestRouterHandleStopsOnFirstHandlerError(t *testing.T) {
+	router := message.NewRouter()
+	handlerErr := errors.New("handler failed")
+	calledSecond := false
+
+	require.NoError(t, router.Subscribe(handlerFunc{
+		kinds: []message.Kind{"test.TestModel"},
+		handle: func(context.Context, message.Message) error {
+			return handlerErr
+		},
+	}))
+	require.NoError(t, router.Subscribe(handlerFunc{
+		kinds: []message.Kind{"test.TestModel"},
+		handle: func(context.Context, message.Message) error {
+			calledSecond = true
+			return nil
+		},
+	}))
+
+	err := router.Handle(context.Background(), newTestMessage(t, "test.TestModel"))
+
+	require.ErrorIs(t, err, handlerErr)
+	require.False(t, calledSecond)
+}

--- a/ddd/message/router_test.go
+++ b/ddd/message/router_test.go
@@ -56,6 +56,17 @@ func TestRouterSubscribeRejectsNoListening(t *testing.T) {
 	require.ErrorIs(t, router.Subscribe(handlerFunc{}), message.ErrNoListening)
 }
 
+// Intent: a handler with an empty listened kind should be rejected before it
+// can register an unroutable subscription.
+func TestRouterSubscribeRejectsEmptyKind(t *testing.T) {
+	router := message.NewRouter()
+
+	require.ErrorIs(t, router.Subscribe(handlerFunc{
+		kinds: []message.Kind{""},
+	}), message.ErrEmptyKind)
+	require.ErrorIs(t, router.Handle(context.Background(), message.Message{}), message.ErrUnhandledKind)
+}
+
 // Intent: an integration message without a matching handler should surface as
 // an error so the broker adapter can choose nack, retry, or failure recording.
 func TestRouterHandleUnhandledKind(t *testing.T) {
@@ -88,6 +99,24 @@ func TestRouterHandleCallsMatchingHandlersInSubscriptionOrder(t *testing.T) {
 
 	require.NoError(t, router.Handle(context.Background(), newTestMessage(t, "test.TestModel")))
 	require.Equal(t, []string{"first", "second"}, seen)
+}
+
+// Intent: repeated listened kinds from one handler should preserve one
+// deterministic delivery for a matching message.
+func TestRouterSubscribeDeduplicatesHandlerKinds(t *testing.T) {
+	router := message.NewRouter()
+	calls := 0
+
+	require.NoError(t, router.Subscribe(handlerFunc{
+		kinds: []message.Kind{"test.TestModel", "test.TestModel"},
+		handle: func(context.Context, message.Message) error {
+			calls++
+			return nil
+		},
+	}))
+
+	require.NoError(t, router.Handle(context.Background(), newTestMessage(t, "test.TestModel")))
+	require.Equal(t, 1, calls)
 }
 
 // Intent: handlers for unrelated integration message kinds must not receive a

--- a/docs/project-knowledge/architecture.md
+++ b/docs/project-knowledge/architecture.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
-triggered_by_plan: 2026-05-10-ddd-event-implementation.md
+triggered_by_plan: 2026-05-10-integration-message.md
 ---
 
 # Architecture
@@ -12,8 +12,8 @@ This repository is a public Go component library. Packages are organized as
 small top-level capabilities instead of an application with service entry
 points, deployment manifests, or bounded-context folders.
 
-The current event branch keeps the existing `mediator` package compatible and
-adds a DDD concept namespace under `ddd/`.
+The current event and message work keeps the existing `mediator` package
+compatible and adds DDD concept packages under `ddd/`.
 
 ## System Context
 
@@ -29,6 +29,7 @@ adds a DDD concept namespace under `ddd/`.
 - `logger/` and `sloghelper/` — logger adapters and helpers for `log/slog`.
 - `mediator/` — existing in-process event mediator with global default, event collection, subscription, dispatch, and graceful shutdown.
 - `ddd/event/` — DDD-oriented domain event collection, batch dispatch, and handler subscription. Key abstractions: `Event`, `Collection`, `Dispatcher`, `Subscriber`, `InMemoryDispatcher`, `Handler`.
+- `ddd/message/` — protobuf-first integration message DTO construction and deterministic handler routing for cross-context messaging. Key abstractions: `Message`, `Kind`, `Publisher`, `Subscriber`, `Handler`, `Router`.
 - `validation/` — notification and specification validation helpers.
 - `docs/superpowers/specs/` and `docs/superpowers/plans/` — design and implementation records for planned or recently completed work.
 
@@ -88,4 +89,4 @@ stateDiagram-v2
 ## Key Design Decisions
 
 - Preserve existing `mediator` API compatibility; add new DDD event module separately. See `decisions.md`.
-- Place DDD concept packages under `ddd/`, with `ddd/event` first and future `ddd/message` / `ddd/message/outbox` reserved. See `docs/superpowers/specs/2026-05-10-ddd-event-design.md`.
+- Place DDD concept packages under `ddd/`, with `ddd/event` for internal domain events and `ddd/message` for integration DTOs. See `decisions.md`.

--- a/docs/project-knowledge/conventions.md
+++ b/docs/project-knowledge/conventions.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-05-10
-updated_by: superpowers-memory:rebuild
-triggered_by_plan: null
+updated_by: superpowers-memory:update
+triggered_by_plan: 2026-05-10-integration-message.md
 ---
 
 # Conventions
@@ -23,6 +23,8 @@ triggered_by_plan: null
 - `mediator` remains the compatibility package for existing users.
 - `ddd/event` should document that it is for domain events inside one bounded context.
 - Domain event handlers in the planned module are follow-up reactions and do not report success back to the previous transaction.
+- `ddd/message` is for protobuf integration DTOs crossing bounded-context or service boundaries; it must remain separate from `ddd/event`.
+- Broker-specific envelope, acknowledgement, retry, DLQ, and outbox behavior should live outside the `ddd/message` core package.
 
 ## Git And CI
 

--- a/docs/project-knowledge/decisions.md
+++ b/docs/project-knowledge/decisions.md
@@ -14,7 +14,7 @@ Pointer: `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 
 ## Use `ddd/` as a DDD concept namespace
 
-Decision: reserve `ddd/event`, future `ddd/message`, and future `ddd/message/outbox`.
+Decision: reserve `ddd/event` and `ddd/message` as DDD concept packages, with `ddd/message/outbox` left for future reliability work.
 Trade-off: improves naming consistency, but package documentation must clarify that `ddd/` is not an application Domain Layer directory.
 Pointer: `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 

--- a/docs/project-knowledge/decisions.md
+++ b/docs/project-knowledge/decisions.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-05-10
-updated_by: superpowers-memory:rebuild
-triggered_by_plan: null
+updated_by: superpowers-memory:update
+triggered_by_plan: 2026-05-10-integration-message.md
 ---
 
 # Decisions
@@ -17,3 +17,9 @@ Pointer: `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 Decision: reserve `ddd/event`, future `ddd/message`, and future `ddd/message/outbox`.
 Trade-off: improves naming consistency, but package documentation must clarify that `ddd/` is not an application Domain Layer directory.
 Pointer: `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
+
+## Model integration messages as protobuf DTOs separate from domain events
+
+Decision: add `ddd/message` with a shared `Message` struct and handler router instead of exposing broker-specific envelopes or reusing `ddd/event.Event`.
+Trade-off: keeps Kafka/RabbitMQ-style adapters interoperable through one message shape, but the core package is protobuf-first rather than payload-format agnostic.
+Pointer: `docs/superpowers/specs/2026-05-10-integration-message-design.md`

--- a/docs/project-knowledge/features.md
+++ b/docs/project-knowledge/features.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
-triggered_by_plan: 2026-05-10-ddd-event-implementation.md
+triggered_by_plan: 2026-05-10-integration-message.md
 ---
 
 # Features
@@ -68,6 +68,22 @@ triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 - Actors / Entry Points: application services configure `ddd/event.Dispatcher` options and consume logs or runtime hooks.
 - Capability Boundary: diagnostics for domain event dispatch only; forced shutdown pending events are best-effort offline compensation clues, not a durable event audit log.
 - References: `ddd/event/`, `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
+
+### DDD Message
+
+#### Protobuf integration message DTOs
+
+- Enables: consumers create transport-neutral integration messages for cross bounded-context or service communication.
+- Actors / Entry Points: application or infrastructure mapping code calls `message.New`, `KindOf`, and message option helpers.
+- Capability Boundary: direct non-transactional integration messaging only; outbox, retry, DLQ, and concrete broker adapters remain outside the core package.
+- References: `ddd/message/`, `docs/superpowers/specs/2026-05-10-integration-message-design.md`
+
+#### Integration message routing
+
+- Enables: consumers route received integration messages to handlers by message kind.
+- Actors / Entry Points: consumers register `message.Handler` values through `message.Router` or a `Subscriber`.
+- Capability Boundary: router handles in-process handler matching and first-error stop; acknowledgement, offset commit, and broker envelope mapping belong to adapters.
+- References: `ddd/message/`, `docs/superpowers/specs/2026-05-10-integration-message-design.md`
 
 ### Validation
 

--- a/docs/project-knowledge/glossary.md
+++ b/docs/project-knowledge/glossary.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
-triggered_by_plan: 2026-05-10-ddd-event-implementation.md
+triggered_by_plan: 2026-05-10-integration-message.md
 ---
 
 # Glossary
@@ -18,6 +18,16 @@ triggered_by_plan: 2026-05-10-ddd-event-implementation.md
 
 **Abandoned Batch** — Accepted `ddd/event` batch not confirmed as handled before forced close interruption. → `ddd/event/`
 
-**Integration Message** — Future cross bounded-context/service contract, separate from domain events. → `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
+**Integration Message** — Protobuf DTO plus delivery metadata crossing bounded-context or service boundaries. → `ddd/message/`
 
-**Outbox** — Future reliability mechanism for integration messages, not a domain event dispatcher. → `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
+**Message Kind** — Integration message contract identifier used for routing and handler matching. → `ddd/message/`
+
+**Message Key** — Transport-neutral ordering or routing group for an integration message. → `ddd/message/`
+
+**Publisher** — Capability interface that directly hands off an integration message to a messaging runtime. → `ddd/message/`
+
+**Subscriber** — Capability interface that registers integration message handlers. → `ddd/message/`
+
+**Router** — In-process integration message handler router keyed by message kind. → `ddd/message/`
+
+**Outbox** — Future reliability mechanism for integration messages, not a domain event dispatcher. → `docs/superpowers/specs/2026-05-10-integration-message-design.md`

--- a/docs/project-knowledge/index.md
+++ b/docs/project-knowledge/index.md
@@ -1,15 +1,15 @@
 ---
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
-triggered_by_plan: 2026-05-10-ddd-event-implementation.md
-covers_branch: hotfix/event@d685f59
+triggered_by_plan: 2026-05-10-integration-message.md
+covers_branch: release/message@5d7b730
 ---
 
 # Project Knowledge Index
 
-- `architecture.md` — top-level Go component layout including the new `ddd/event` DDD concept package.
-- `features.md` — current capabilities including legacy `mediator`, `ddd/event` collection, split dispatcher/subscriber APIs, in-memory dispatcher, and diagnostics.
+- `architecture.md` — top-level Go component layout including `ddd/event` for domain events and `ddd/message` for integration DTO messages.
+- `features.md` — current capabilities including legacy `mediator`, `ddd/event`, `ddd/message` construction/routing, and diagnostics.
 - `tech-stack.md` — Go 1.24 module, CI matrix 1.23/1.24/1.25, core dependencies and Make targets.
-- `conventions.md` — package style, tests with `go test -race -covermode=atomic`, CI/benchmark workflow.
-- `decisions.md` — design decision summary for preserving `mediator` and adding `ddd/event`.
-- `glossary.md` — project terms including legacy mediator, domain event, event collection, dispatcher/subscriber, in-memory dispatcher diagnostics, integration message, and outbox.
+- `conventions.md` — package style, DDD event/message boundaries, tests with `go test -race -covermode=atomic`, CI/benchmark workflow.
+- `decisions.md` — design decision summary for preserving `mediator`, adding `ddd/event`, and modeling `ddd/message` separately.
+- `glossary.md` — project terms including legacy mediator, domain event, integration message, message kind/key, router, and outbox.

--- a/docs/superpowers/plans/2026-05-10-integration-message.md
+++ b/docs/superpowers/plans/2026-05-10-integration-message.md
@@ -1,0 +1,816 @@
+# Integration Message Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `ddd/message`, a protobuf-first, non-transactional integration messaging abstraction with a transport-neutral `Message` struct, publish/subscribe interfaces, and a reusable handler router.
+
+**Architecture:** `ddd/message` is separate from `ddd/event`; domain events remain internal facts and integration messages are cross-context DTO contracts. `Message` is a struct so all publishers and handlers share one transport-neutral shape; broker envelopes stay inside future adapter packages. `Router` provides deterministic sequential handler dispatch for broker adapters and tests.
+
+**Tech Stack:** Go 1.24, `google.golang.org/protobuf/proto`, standard library `crypto/rand`, `encoding/hex`, `sync`, `time`, and existing `github.com/stretchr/testify/require` test style.
+
+---
+
+## Source Spec
+
+- `docs/superpowers/specs/2026-05-10-integration-message-design.md`
+
+## Architecture Gate
+
+- Gate level: Level 3, because this adds a new DDD concept package and cross-context messaging boundary.
+- Bounded context / business capability: shared component library capability for non-transactional integration messaging across bounded contexts or services.
+- Stable language / data authority: `message.Message` is a cross-context integration DTO with delivery metadata; it is not a domain event, domain entity, or persistence DO.
+- Affected aggregate, policy, or service: no business aggregate; affects message construction, publisher/subscriber interfaces, handler routing, and future broker adapter boundaries.
+- Invariants and rules: domain code raises `ddd/event.Event` only; application or infrastructure mapping code creates `ddd/message.Message`; handlers consume protobuf DTO contracts rather than publisher-internal domain event structs.
+- Technical capability classification: message construction is an application contract concern; broker publish/consume mechanics are infrastructure; router is reusable application/runtime orchestration.
+- Layer ownership: Domain owns domain events. Application owns mapping and publish decisions. Infrastructure owns broker-specific envelopes, acknowledgement, offset, and transport mapping.
+- Proceed / Stop: proceed with implementation tasks below.
+
+## Scope Check
+
+This plan covers one subsystem: direct, non-transactional integration messaging in `ddd/message`.
+
+Outbox, relay, database schema, retry, DLQ, delay, concrete Kafka/RabbitMQ/NATS adapters, and ConnectRPC generation are out of scope.
+
+## File Structure
+
+- Create `ddd/message/doc.go`: package documentation and boundary statement.
+- Create `ddd/message/errors.go`: sentinel validation and routing errors.
+- Create `ddd/message/message.go`: `Kind`, `Message`, `New`, accessors, `KindOf`, and default ID generation.
+- Create `ddd/message/option.go`: construction option type and option helpers.
+- Create `ddd/message/router.go`: `Publisher`, `Handler`, `Subscriber`, `Router`, and routing behavior.
+- Create `ddd/message/message_test.go`: real unit tests for message construction and metadata immutability.
+- Create `ddd/message/router_test.go`: real unit tests for router subscription, matching, and error behavior.
+- Modify `docs/project-knowledge/*.md`: only after code is complete, update project knowledge through `superpowers-memory:update`.
+
+## Intent-First Test List
+
+Intent source: approved design spec `2026-05-10-integration-message-design.md`.
+
+- [ ] unit real: creating a message with empty kind -> returns `ErrEmptyKind`.
+- [ ] unit real: creating a message with nil protobuf payload -> returns `ErrNilPayload`.
+- [ ] unit real: creating a valid message with required inputs only -> returns non-empty generated ID, requested kind, payload, and non-zero occurrence time.
+- [ ] unit real: explicit ID, key, occurrence time, and headers -> accessors return those values.
+- [ ] unit real: input headers are copied -> mutating caller map after construction does not alter the message.
+- [ ] unit real: returned headers are copied -> mutating accessor result does not alter the message.
+- [ ] unit real: `KindOf` on protobuf payload -> returns protobuf full name; nil payload returns empty kind.
+- [ ] unit real: router implements `Subscriber`.
+- [ ] unit real: subscribing a nil handler -> returns `ErrNilHandler`.
+- [ ] unit real: subscribing a handler with no listened kinds -> returns `ErrNoListening`.
+- [ ] unit real: handling a message with no matching handler -> returns `ErrUnhandledKind`.
+- [ ] unit real: handling a message with matching handlers -> calls handlers in subscription order.
+- [ ] unit real: handling a message does not call handlers for other kinds -> unrelated handlers are skipped.
+- [ ] unit real: first handler error -> router stops and returns that error.
+
+Each test is at the lowest reliable boundary: pure unit tests for message construction and router routing. No mocks are needed; handler fakes exercise the real router.
+
+---
+
+### Task 1: Message Value And Construction
+
+**Files:**
+- Create: `ddd/message/doc.go`
+- Create: `ddd/message/errors.go`
+- Create: `ddd/message/message.go`
+- Create: `ddd/message/option.go`
+- Test: `ddd/message/message_test.go`
+
+- [ ] **Step 1: Write failing message construction tests**
+
+Create `ddd/message/message_test.go`:
+
+```go
+package message_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message"
+	testdata "github.com/go-jimu/components/encoding/testdata"
+	"github.com/stretchr/testify/require"
+)
+
+// Intent: integration messages must have a contract kind so publishers and
+// subscribers can route them deterministically.
+func TestNewRejectsEmptyKind(t *testing.T) {
+	msg, err := message.New("", &testdata.TestModel{})
+
+	require.ErrorIs(t, err, message.ErrEmptyKind)
+	require.Equal(t, message.Message{}, msg)
+}
+
+// Intent: integration messages must carry a protobuf DTO payload rather than
+// only delivery metadata.
+func TestNewRejectsNilPayload(t *testing.T) {
+	msg, err := message.New("test.TestModel", nil)
+
+	require.ErrorIs(t, err, message.ErrNilPayload)
+	require.Equal(t, message.Message{}, msg)
+}
+
+// Intent: callers that provide only the required contract data should still get
+// a publishable message with generated identity and occurrence metadata.
+func TestNewDefaultsIDAndOccurredAt(t *testing.T) {
+	payload := &testdata.TestModel{Id: 42, Name: "paid"}
+
+	before := time.Now()
+	msg, err := message.New("test.TestModel", payload)
+	after := time.Now()
+
+	require.NoError(t, err)
+	require.NotEmpty(t, msg.ID())
+	require.Equal(t, message.Kind("test.TestModel"), msg.Kind())
+	require.Empty(t, msg.Key())
+	require.Same(t, payload, msg.Payload())
+	require.True(t, !msg.OccurredAt().Before(before) && !msg.OccurredAt().After(after))
+	require.Empty(t, msg.Headers())
+}
+
+// Intent: mapping code must be able to preserve domain fact time, idempotency
+// ID, ordering key, and cross-service metadata when creating a message.
+func TestNewAppliesExplicitMetadata(t *testing.T) {
+	occurredAt := time.Date(2026, 5, 10, 12, 30, 0, 0, time.UTC)
+	payload := &testdata.TestModel{Id: 7, Name: "confirmed"}
+
+	msg, err := message.New(
+		"test.TestModel",
+		payload,
+		message.WithID("msg-1"),
+		message.WithKey("order-7"),
+		message.WithOccurredAt(occurredAt),
+		message.WithHeader("trace_id", "trace-1"),
+		message.WithHeaders(map[string]string{"tenant": "tenant-a"}),
+	)
+
+	require.NoError(t, err)
+	require.Equal(t, "msg-1", msg.ID())
+	require.Equal(t, message.Kind("test.TestModel"), msg.Kind())
+	require.Equal(t, "order-7", msg.Key())
+	require.Equal(t, occurredAt, msg.OccurredAt())
+	require.Same(t, payload, msg.Payload())
+	require.Equal(t, map[string]string{
+		"trace_id": "trace-1",
+		"tenant":   "tenant-a",
+	}, msg.Headers())
+}
+
+// Intent: explicitly setting an empty ID should fail instead of creating a
+// message that cannot support idempotency or tracing.
+func TestNewRejectsExplicitEmptyID(t *testing.T) {
+	msg, err := message.New(
+		"test.TestModel",
+		&testdata.TestModel{},
+		message.WithID(""),
+	)
+
+	require.ErrorIs(t, err, message.ErrEmptyID)
+	require.Equal(t, message.Message{}, msg)
+}
+
+// Intent: message metadata should be stable after construction even if caller
+// code mutates the original headers map.
+func TestNewCopiesHeadersOnInput(t *testing.T) {
+	headers := map[string]string{"trace_id": "trace-1"}
+	msg, err := message.New(
+		"test.TestModel",
+		&testdata.TestModel{},
+		message.WithHeaders(headers),
+	)
+	require.NoError(t, err)
+
+	headers["trace_id"] = "changed"
+	headers["tenant"] = "tenant-a"
+
+	require.Equal(t, map[string]string{"trace_id": "trace-1"}, msg.Headers())
+}
+
+// Intent: consumers should not be able to mutate message metadata through the
+// Headers accessor.
+func TestHeadersReturnsCopy(t *testing.T) {
+	msg, err := message.New(
+		"test.TestModel",
+		&testdata.TestModel{},
+		message.WithHeader("trace_id", "trace-1"),
+	)
+	require.NoError(t, err)
+
+	headers := msg.Headers()
+	headers["trace_id"] = "changed"
+	headers["tenant"] = "tenant-a"
+
+	require.Equal(t, map[string]string{"trace_id": "trace-1"}, msg.Headers())
+}
+
+// Intent: protobuf-first callers should be able to derive the integration
+// message kind from the protobuf contract name.
+func TestKindOf(t *testing.T) {
+	require.Equal(t, message.Kind("test.test_model"), message.KindOf(&testdata.TestModel{}))
+	require.Equal(t, message.Kind(""), message.KindOf(nil))
+}
+```
+
+- [ ] **Step 2: Run message tests to verify they fail**
+
+Run:
+
+```bash
+go test ./ddd/message -run 'TestNew|TestHeaders|TestKindOf' -count=1
+```
+
+Expected: FAIL because `ddd/message` package does not exist yet, or because the tested symbols are undefined.
+
+- [ ] **Step 3: Add package documentation**
+
+Create `ddd/message/doc.go`:
+
+```go
+// Package message provides protobuf-first integration message primitives for
+// asynchronous communication across bounded contexts or services.
+//
+// The package is intentionally separate from ddd/event. Domain events are
+// internal facts raised inside one bounded context; integration messages are
+// external DTO contracts. Application or infrastructure mapping code may
+// convert selected domain events into messages, but this package does not
+// import ddd/event.
+//
+// Publish provides direct, non-transactional handoff semantics. It does not
+// provide outbox reliability or atomic commit with business data.
+package message
+```
+
+- [ ] **Step 4: Add sentinel errors**
+
+Create `ddd/message/errors.go`:
+
+```go
+package message
+
+import "errors"
+
+var (
+	ErrEmptyKind     = errors.New("message kind is empty")
+	ErrNilPayload    = errors.New("message payload is nil")
+	ErrEmptyID       = errors.New("message id is empty")
+	ErrNilHandler    = errors.New("message handler is nil")
+	ErrNoListening   = errors.New("message handler listens to no kinds")
+	ErrUnhandledKind = errors.New("message kind has no handler")
+)
+```
+
+- [ ] **Step 5: Add message construction options**
+
+Create `ddd/message/option.go`:
+
+```go
+package message
+
+import "time"
+
+type Option func(*messageConfig)
+
+type messageConfig struct {
+	id         string
+	hasID      bool
+	key        string
+	occurredAt time.Time
+	headers    map[string]string
+}
+
+func WithID(id string) Option {
+	return func(cfg *messageConfig) {
+		cfg.id = id
+		cfg.hasID = true
+	}
+}
+
+func WithKey(key string) Option {
+	return func(cfg *messageConfig) {
+		cfg.key = key
+	}
+}
+
+func WithOccurredAt(t time.Time) Option {
+	return func(cfg *messageConfig) {
+		cfg.occurredAt = t
+	}
+}
+
+func WithHeader(key, value string) Option {
+	return func(cfg *messageConfig) {
+		if cfg.headers == nil {
+			cfg.headers = make(map[string]string)
+		}
+		cfg.headers[key] = value
+	}
+}
+
+func WithHeaders(headers map[string]string) Option {
+	return func(cfg *messageConfig) {
+		if len(headers) == 0 {
+			return
+		}
+		if cfg.headers == nil {
+			cfg.headers = make(map[string]string, len(headers))
+		}
+		for key, value := range headers {
+			cfg.headers[key] = value
+		}
+	}
+}
+```
+
+- [ ] **Step 6: Add Message, constructor, accessors, KindOf, and ID generation**
+
+Create `ddd/message/message.go`:
+
+```go
+package message
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+)
+
+type Kind string
+
+type Message struct {
+	id         string
+	kind       Kind
+	key        string
+	occurredAt time.Time
+	payload    proto.Message
+	headers    map[string]string
+}
+
+func New(kind Kind, payload proto.Message, opts ...Option) (Message, error) {
+	if kind == "" {
+		return Message{}, ErrEmptyKind
+	}
+	if payload == nil {
+		return Message{}, ErrNilPayload
+	}
+
+	var cfg messageConfig
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+
+	id := cfg.id
+	if cfg.hasID {
+		if id == "" {
+			return Message{}, ErrEmptyID
+		}
+	} else {
+		generated, err := generateID()
+		if err != nil {
+			return Message{}, err
+		}
+		id = generated
+	}
+
+	occurredAt := cfg.occurredAt
+	if occurredAt.IsZero() {
+		occurredAt = time.Now()
+	}
+
+	return Message{
+		id:         id,
+		kind:       kind,
+		key:        cfg.key,
+		occurredAt: occurredAt,
+		payload:    payload,
+		headers:    cloneHeaders(cfg.headers),
+	}, nil
+}
+
+func (m Message) ID() string {
+	return m.id
+}
+
+func (m Message) Kind() Kind {
+	return m.kind
+}
+
+func (m Message) Key() string {
+	return m.key
+}
+
+func (m Message) OccurredAt() time.Time {
+	return m.occurredAt
+}
+
+func (m Message) Payload() proto.Message {
+	return m.payload
+}
+
+func (m Message) Headers() map[string]string {
+	return cloneHeaders(m.headers)
+}
+
+func KindOf(payload proto.Message) Kind {
+	if payload == nil {
+		return ""
+	}
+	return Kind(payload.ProtoReflect().Descriptor().FullName())
+}
+
+func cloneHeaders(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(headers))
+	for key, value := range headers {
+		copied[key] = value
+	}
+	return copied
+}
+
+func generateID() (string, error) {
+	var bytes [16]byte
+	if _, err := rand.Read(bytes[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(bytes[:]), nil
+}
+```
+
+- [ ] **Step 7: Run message tests to verify they pass**
+
+Run:
+
+```bash
+go test ./ddd/message -run 'TestNew|TestHeaders|TestKindOf' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Format and commit Task 1**
+
+Run:
+
+```bash
+gofmt -w ddd/message/doc.go ddd/message/errors.go ddd/message/message.go ddd/message/option.go ddd/message/message_test.go
+go test ./ddd/message -run 'TestNew|TestHeaders|TestKindOf' -count=1
+git add ddd/message/doc.go ddd/message/errors.go ddd/message/message.go ddd/message/option.go ddd/message/message_test.go
+git commit -m "feat: add integration message value"
+```
+
+Expected: tests pass and commit succeeds.
+
+---
+
+### Task 2: Router And Messaging Interfaces
+
+**Files:**
+- Create: `ddd/message/router.go`
+- Test: `ddd/message/router_test.go`
+
+- [ ] **Step 1: Write failing router tests**
+
+Create `ddd/message/router_test.go`:
+
+```go
+package message_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-jimu/components/ddd/message"
+	testdata "github.com/go-jimu/components/encoding/testdata"
+	"github.com/stretchr/testify/require"
+)
+
+type handlerFunc struct {
+	kinds  []message.Kind
+	handle func(context.Context, message.Message) error
+}
+
+func (h handlerFunc) Listening() []message.Kind {
+	return h.kinds
+}
+
+func (h handlerFunc) Handle(ctx context.Context, msg message.Message) error {
+	if h.handle == nil {
+		return nil
+	}
+	return h.handle(ctx, msg)
+}
+
+func newTestMessage(t *testing.T, kind message.Kind) message.Message {
+	t.Helper()
+
+	msg, err := message.New(kind, &testdata.TestModel{Id: 1})
+	require.NoError(t, err)
+	return msg
+}
+
+// Intent: broker adapters should be able to depend on the Subscriber
+// capability without knowing the concrete router type.
+func TestRouterImplementsSubscriber(t *testing.T) {
+	var _ message.Subscriber = message.NewRouter()
+}
+
+// Intent: registering a nil handler should fail before a consumer silently
+// drops all messages for a kind.
+func TestRouterSubscribeRejectsNilHandler(t *testing.T) {
+	router := message.NewRouter()
+
+	require.ErrorIs(t, router.Subscribe(nil), message.ErrNilHandler)
+}
+
+// Intent: a handler that listens to no kinds cannot be matched and should be
+// rejected during subscription.
+func TestRouterSubscribeRejectsNoListening(t *testing.T) {
+	router := message.NewRouter()
+
+	require.ErrorIs(t, router.Subscribe(handlerFunc{}), message.ErrNoListening)
+}
+
+// Intent: an integration message without a matching handler should surface as
+// an error so the broker adapter can choose nack, retry, or failure recording.
+func TestRouterHandleUnhandledKind(t *testing.T) {
+	router := message.NewRouter()
+	msg := newTestMessage(t, "test.TestModel")
+
+	require.ErrorIs(t, router.Handle(context.Background(), msg), message.ErrUnhandledKind)
+}
+
+// Intent: matching handlers should run in subscription order to keep direct
+// in-process routing deterministic.
+func TestRouterHandleCallsMatchingHandlersInSubscriptionOrder(t *testing.T) {
+	router := message.NewRouter()
+	seen := make([]string, 0, 2)
+
+	require.NoError(t, router.Subscribe(handlerFunc{
+		kinds: []message.Kind{"test.TestModel"},
+		handle: func(context.Context, message.Message) error {
+			seen = append(seen, "first")
+			return nil
+		},
+	}))
+	require.NoError(t, router.Subscribe(handlerFunc{
+		kinds: []message.Kind{"test.TestModel"},
+		handle: func(context.Context, message.Message) error {
+			seen = append(seen, "second")
+			return nil
+		},
+	}))
+
+	require.NoError(t, router.Handle(context.Background(), newTestMessage(t, "test.TestModel")))
+	require.Equal(t, []string{"first", "second"}, seen)
+}
+
+// Intent: handlers for unrelated integration message kinds must not receive a
+// message just because they share the same router.
+func TestRouterHandleSkipsOtherKinds(t *testing.T) {
+	router := message.NewRouter()
+	seen := make([]string, 0, 1)
+
+	require.NoError(t, router.Subscribe(handlerFunc{
+		kinds: []message.Kind{"other.Kind"},
+		handle: func(context.Context, message.Message) error {
+			seen = append(seen, "other")
+			return nil
+		},
+	}))
+	require.NoError(t, router.Subscribe(handlerFunc{
+		kinds: []message.Kind{"test.TestModel"},
+		handle: func(context.Context, message.Message) error {
+			seen = append(seen, "target")
+			return nil
+		},
+	}))
+
+	require.NoError(t, router.Handle(context.Background(), newTestMessage(t, "test.TestModel")))
+	require.Equal(t, []string{"target"}, seen)
+}
+
+// Intent: when a handler fails, the router should stop so a broker adapter can
+// avoid acknowledging a partially handled message.
+func TestRouterHandleStopsOnFirstHandlerError(t *testing.T) {
+	router := message.NewRouter()
+	handlerErr := errors.New("handler failed")
+	calledSecond := false
+
+	require.NoError(t, router.Subscribe(handlerFunc{
+		kinds: []message.Kind{"test.TestModel"},
+		handle: func(context.Context, message.Message) error {
+			return handlerErr
+		},
+	}))
+	require.NoError(t, router.Subscribe(handlerFunc{
+		kinds: []message.Kind{"test.TestModel"},
+		handle: func(context.Context, message.Message) error {
+			calledSecond = true
+			return nil
+		},
+	}))
+
+	err := router.Handle(context.Background(), newTestMessage(t, "test.TestModel"))
+
+	require.ErrorIs(t, err, handlerErr)
+	require.False(t, calledSecond)
+}
+```
+
+- [ ] **Step 2: Run router tests to verify they fail**
+
+Run:
+
+```bash
+go test ./ddd/message -run 'TestRouter' -count=1
+```
+
+Expected: FAIL because `NewRouter`, `Subscriber`, `Handler`, or router methods are undefined.
+
+- [ ] **Step 3: Add router and interfaces**
+
+Create `ddd/message/router.go`:
+
+```go
+package message
+
+import (
+	"context"
+	"sync"
+)
+
+type Publisher interface {
+	Publish(context.Context, Message) error
+}
+
+type Handler interface {
+	Listening() []Kind
+	Handle(context.Context, Message) error
+}
+
+type Subscriber interface {
+	Subscribe(Handler) error
+}
+
+type Router struct {
+	mu       sync.RWMutex
+	handlers map[Kind][]Handler
+}
+
+var _ Subscriber = (*Router)(nil)
+
+func NewRouter() *Router {
+	return &Router{
+		handlers: make(map[Kind][]Handler),
+	}
+}
+
+func (r *Router) Subscribe(handler Handler) error {
+	if handler == nil {
+		return ErrNilHandler
+	}
+
+	kinds := handler.Listening()
+	if len(kinds) == 0 {
+		return ErrNoListening
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, kind := range kinds {
+		r.handlers[kind] = append(r.handlers[kind], handler)
+	}
+	return nil
+}
+
+func (r *Router) Handle(ctx context.Context, msg Message) error {
+	r.mu.RLock()
+	handlers := append([]Handler(nil), r.handlers[msg.Kind()]...)
+	r.mu.RUnlock()
+
+	if len(handlers) == 0 {
+		return ErrUnhandledKind
+	}
+
+	for _, handler := range handlers {
+		if err := handler.Handle(ctx, msg); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run router tests to verify they pass**
+
+Run:
+
+```bash
+go test ./ddd/message -run 'TestRouter' -count=1
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Format and commit Task 2**
+
+Run:
+
+```bash
+gofmt -w ddd/message/router.go ddd/message/router_test.go
+go test ./ddd/message -count=1
+git add ddd/message/router.go ddd/message/router_test.go
+git commit -m "feat: add integration message router"
+```
+
+Expected: package tests pass and commit succeeds.
+
+---
+
+### Task 3: Full Verification And Project Knowledge
+
+**Files:**
+- Modify: `docs/project-knowledge/architecture.md`
+- Modify: `docs/project-knowledge/features.md`
+- Modify: `docs/project-knowledge/decisions.md`
+- Modify: `docs/project-knowledge/glossary.md`
+- Modify: `docs/project-knowledge/index.md`
+
+- [ ] **Step 1: Run the full repository test suite**
+
+Run:
+
+```bash
+go test ./...
+```
+
+Expected: PASS for all packages.
+
+- [ ] **Step 2: Run the race-enabled project test target**
+
+Run:
+
+```bash
+make test
+```
+
+Expected: PASS. This is the repository convention from `docs/project-knowledge/conventions.md`.
+
+- [ ] **Step 3: Update project knowledge**
+
+Invoke `superpowers-memory:update` and update the project knowledge base so it reflects the new `ddd/message` package.
+
+The knowledge update should capture:
+
+- `architecture.md`: add `ddd/message` as the integration messaging package next to `ddd/event`.
+- `features.md`: add non-transactional protobuf integration messaging, message router, and handler interfaces.
+- `decisions.md`: record the decision to model integration messages as DTO structs separate from domain events and broker envelopes.
+- `glossary.md`: add or refine `Integration Message`, `Message Kind`, `Message Key`, `Publisher`, `Subscriber`, and `Router`.
+- `index.md`: update `last_updated`, branch/commit metadata, and summaries if the update tool changes them.
+
+- [ ] **Step 4: Review project knowledge diff**
+
+Run:
+
+```bash
+git diff -- docs/project-knowledge
+```
+
+Expected: diff mentions `ddd/message` and does not remove current `ddd/event` or `mediator` knowledge.
+
+- [ ] **Step 5: Commit verification and knowledge updates**
+
+Run:
+
+```bash
+git status --short
+git add docs/project-knowledge
+git commit -m "docs: update project knowledge for integration messages"
+```
+
+Expected: only project knowledge files are staged for this commit, and commit succeeds. If `superpowers-memory:update` reports no changes, skip this commit and note that the knowledge base was already current.
+
+## Final Verification
+
+After all tasks:
+
+```bash
+go test ./...
+make test
+git status --short
+```
+
+Expected:
+
+- all tests pass
+- `make test` passes
+- working tree is clean except for intentional uncommitted user changes
+
+## Self-Review Notes
+
+- Spec coverage: message struct, fields, constructor options, publisher/subscriber/handler interfaces, router, errors, docs, and tests are covered. Outbox, concrete brokers, retry, DLQ, and ConnectRPC generation remain out of scope.
+- Placeholder scan: no incomplete-marker or fill-in steps are used.
+- Type consistency: the plan uses `message.Kind`, `message.Message`, `message.Publisher`, `message.Handler`, `message.Subscriber`, and `message.Router` consistently across tests and implementation.

--- a/docs/superpowers/specs/2026-05-10-integration-message-design.md
+++ b/docs/superpowers/specs/2026-05-10-integration-message-design.md
@@ -1,0 +1,393 @@
+# Integration Message Module Design
+
+Date: 2026-05-10
+Status: Draft for review
+
+## Purpose
+
+Add a protobuf-first integration messaging abstraction for asynchronous
+communication across bounded contexts or services.
+
+The first module is:
+
+```text
+ddd/message
+```
+
+This design covers direct, non-transactional integration message publishing and
+handling only. Transactional reliability through the outbox pattern is a later
+module and must build on the message shape defined here.
+
+## Scope
+
+`ddd/message` is for integration DTO messages crossing bounded-context or
+service boundaries.
+
+It is not:
+
+- a domain event dispatcher
+- a replacement for `ddd/event`
+- a ConnectRPC request/response abstraction
+- a broker-specific envelope API
+- a transactional outbox implementation
+- a relay, retry, dead-letter, or durable delivery framework
+
+The module assumes protobuf is the contract format. It may depend directly on
+`google.golang.org/protobuf/proto`.
+
+## Architecture Gate
+
+- Gate level: Level 3, because this introduces a new DDD concept package and a
+  new cross-context messaging boundary.
+- Bounded context / business capability: shared component library capability for
+  non-transactional integration messaging across bounded contexts or services.
+- Stable language / data authority: `Message` is a cross-context integration DTO
+  with delivery metadata. It is distinct from `ddd/event.Event`, which remains an
+  internal domain fact inside one bounded context.
+- Affected aggregate, policy, or service: no business aggregate. Affects shared
+  message construction, publish, subscribe, handler routing, and direct broker
+  adapter boundaries.
+- Invariants and rules: domain code raises domain events only; application or
+  infrastructure mapping code may convert selected domain events to integration
+  messages; handlers consume stable protobuf DTO contracts, not publisher
+  internal domain event structs.
+- Technical capability classification: message construction is an application
+  contract concern; publishing, subscribing, broker envelopes, offset commits,
+  acknowledgements, and transport mapping are infrastructure concerns; handler
+  routing is reusable application/runtime orchestration.
+- Layer ownership: Domain owns domain events. Application owns the decision to
+  publish an integration message and the mapping from domain facts to protobuf
+  DTOs. Infrastructure owns broker-specific publish/consume mechanics.
+- Proceed / Stop: proceed with design. Implementation requires a separate plan.
+
+## Concept Model
+
+### Domain Event vs Integration Message
+
+`ddd/event.Event` records a fact raised inside one bounded context. Its `Kind`
+is internal to that context and can evolve with the domain model.
+
+`ddd/message.Message` is a protobuf DTO plus transport-neutral delivery metadata
+published across a bounded-context or service boundary. Its `Kind` identifies
+the external message contract and may be mapped to a broker topic, subject, or
+routing key by infrastructure adapters.
+
+The two concepts can be mapped, but they are not the same type:
+
+```text
+ddd/event.Event
+    -> mapper / assembler
+        -> protobuf DTO
+            -> ddd/message.Message
+                -> broker adapter envelope
+```
+
+`ddd/message` must not import `ddd/event`. Applications that need to publish
+messages from domain events provide the mapper in their own application or
+infrastructure layer.
+
+### Integration Message as DTO
+
+For this project, an integration message is treated as a DTO. More precisely, it
+is a cross bounded-context DTO with stronger compatibility expectations than an
+internal command, query, or response DTO.
+
+It is not a domain entity and does not guard business invariants. It is not a
+DO/persistence model. Broker or outbox records may persist a message, but those
+records are infrastructure implementation details.
+
+## Public API
+
+Proposed package:
+
+```go
+package message
+
+import (
+    "context"
+    "time"
+
+    "google.golang.org/protobuf/proto"
+)
+
+type Kind string
+
+type Message struct {
+    // unexported fields
+}
+
+func New(kind Kind, payload proto.Message, opts ...Option) (Message, error)
+
+func (m Message) ID() string
+func (m Message) Kind() Kind
+func (m Message) Key() string
+func (m Message) OccurredAt() time.Time
+func (m Message) Payload() proto.Message
+func (m Message) Headers() map[string]string
+
+type Publisher interface {
+    Publish(context.Context, Message) error
+}
+
+type Handler interface {
+    Listening() []Kind
+    Handle(context.Context, Message) error
+}
+
+type Subscriber interface {
+    Subscribe(Handler) error
+}
+```
+
+`Message` is a struct, not an interface, because it is the standard DTO shape.
+Different publishers and handlers should process the same message type. A
+Kafka-backed message must not become a different public type from a
+RabbitMQ-backed message.
+
+`Publisher`, `Subscriber`, and `Handler` are interfaces because they describe
+capabilities.
+
+## Message Fields
+
+`Message` contains six transport-neutral fields.
+
+| Field | Meaning |
+| --- | --- |
+| `ID` | Unique message instance identifier for idempotency, de-duplication, tracing, and retry correlation. |
+| `Kind` | Integration message contract type. It is used for handler matching and may be mapped to a topic, subject, or routing key. |
+| `Key` | Ordering or routing group. Kafka adapters can map it to the Kafka message key so messages for the same entity are consumed in order when the transport supports it. |
+| `OccurredAt` | Time when the business fact occurred. It is not broker publish time. |
+| `Payload` | Protobuf DTO payload. |
+| `Headers` | Extension metadata such as trace ID, correlation ID, causation ID, tenant, source, or schema hints. |
+
+Fields intentionally not included as first-class API:
+
+- `Topic`, `Partition`, `Exchange`, `Queue`, and `Subject`: broker adapter
+  configuration or envelope details.
+- `Source`, `TraceID`, `CorrelationID`, `CausationID`, `Tenant`, and `Version`:
+  useful metadata, but not universal enough to be first-class fields.
+- `Retry`, `Delay`, `TTL`, `Priority`, and `DLQ`: runtime policy and reliability
+  concerns outside this non-transactional core.
+- `ContentType`: the core is protobuf-first, so payload format is already
+  constrained by the API.
+
+## Message Construction
+
+Construction should validate required fields and copy mutable input:
+
+```go
+type Option func(*messageConfig)
+
+func WithID(id string) Option
+func WithKey(key string) Option
+func WithOccurredAt(t time.Time) Option
+func WithHeader(key, value string) Option
+func WithHeaders(headers map[string]string) Option
+func KindOf(payload proto.Message) Kind
+```
+
+Rules:
+
+- `kind` must not be empty.
+- `payload` must not be nil.
+- `ID` defaults to a generated unique ID and may be overridden.
+- `OccurredAt` defaults to `time.Now()` and may be overridden when mapping from
+  an older domain event or external fact.
+- `Headers` are copied on input and output so callers cannot mutate internal
+  message state through a map reference.
+- `Payload` is returned as the protobuf message supplied by the caller. The
+  message should be treated as immutable after construction. The implementation
+  does not need to clone payloads by default.
+
+`KindOf(payload)` returns the protobuf full name for the payload, for example:
+
+```text
+order.payment.v1.OrderPaid
+```
+
+Callers may still pass an explicit `Kind` when they need a stable name that is
+not exactly the protobuf full name.
+
+## Publishing Semantics
+
+`Publisher.Publish(ctx, msg)` sends one integration message through a direct
+messaging runtime.
+
+Return semantics:
+
+- `nil` means the publisher accepted or handed off the message according to its
+  direct transport implementation.
+- a non-nil error means the message was not accepted or handed off.
+
+`Publish` does not mean:
+
+- the message was atomically committed with business data
+- all consumers processed the message
+- a broker persisted the message durably, unless a concrete publisher documents
+  that behavior
+
+Transactional guarantees belong to a future outbox-backed publisher.
+
+## Subscribing And Handling Semantics
+
+`Handler.Handle` returns an error because integration message consumers usually
+need the broker adapter to choose acknowledgement, offset commit, negative
+acknowledgement, retry, or failure recording behavior.
+
+Handler matching is based on `Kind`:
+
+```go
+type Handler interface {
+    Listening() []Kind
+    Handle(context.Context, Message) error
+}
+```
+
+Unlike `ddd/event`, an unhandled integration message should be treated as an
+error by default. A domain event can be optional inside a bounded context, but an
+integration message received from a broker is an external contract that should
+have an explicit consumer or dead-letter/failure policy.
+
+## Router
+
+The package should provide a reusable transport-neutral router so each broker
+adapter does not duplicate handler matching behavior.
+
+```go
+type Router struct {
+    // unexported fields
+}
+
+func NewRouter() *Router
+func (r *Router) Subscribe(Handler) error
+func (r *Router) Handle(context.Context, Message) error
+```
+
+`Router` responsibilities:
+
+- register handlers by `Kind`
+- reject nil handlers
+- reject handlers with empty listening lists
+- route a message to all handlers listening to its `Kind`
+- return `ErrUnhandledKind` when no handler matches
+- stop and return on the first handler error
+
+The first version should keep routing sequential and deterministic. Concurrent
+handling can be introduced later as a separate implementation or option with
+explicitly documented ordering trade-offs.
+
+## Transport Adapter Mapping
+
+Broker adapters are outside this first design, but the public API must support
+them without leaking their envelope types.
+
+Kafka mapping example:
+
+```text
+Message.Kind()    -> topic or topic mapping rule
+Message.Key()     -> Kafka message key
+Message.ID()      -> header or payload metadata for idempotency
+Message.Headers() -> Kafka headers
+Message.Payload() -> protobuf marshaled bytes
+```
+
+RabbitMQ mapping example:
+
+```text
+Message.Kind()    -> exchange/routing-key mapping rule
+Message.Key()     -> routing key component when useful
+Message.ID()      -> message id property or header
+Message.Headers() -> AMQP headers
+Message.Payload() -> protobuf marshaled bytes
+```
+
+Any concrete adapter may define an internal envelope type such as
+`kafkaEnvelope` or `amqpEnvelope`, but those types must not appear in the
+`ddd/message` core API.
+
+## Errors
+
+The package should expose small sentinel errors for validation and routing:
+
+```go
+var (
+    ErrEmptyKind     = errors.New("message kind is empty")
+    ErrNilPayload    = errors.New("message payload is nil")
+    ErrEmptyID       = errors.New("message id is empty")
+    ErrNilHandler    = errors.New("message handler is nil")
+    ErrNoListening   = errors.New("message handler listens to no kinds")
+    ErrUnhandledKind = errors.New("message kind has no handler")
+)
+```
+
+Concrete publishers and subscribers should wrap transport errors with operation
+context. The core package does not define broker-specific failure categories.
+
+## Documentation Requirements
+
+Package documentation must state:
+
+```text
+ddd/message is for protobuf integration DTO messages crossing bounded-context or
+service boundaries.
+```
+
+```text
+ddd/message is separate from ddd/event. Domain events are internal facts;
+integration messages are external DTO contracts.
+```
+
+```text
+Publish provides direct, non-transactional handoff semantics. It does not
+provide outbox reliability or atomic commit with business data.
+```
+
+```text
+Message.Key is a transport-neutral ordering/routing key. Transports that support
+ordered streams should use it to keep messages for the same entity in the same
+ordered stream.
+```
+
+## Testing Strategy
+
+Tests should verify public semantics.
+
+Message tests:
+
+- `New` rejects empty kind.
+- `New` rejects nil payload.
+- `New` generates a non-empty ID by default.
+- `New` applies an explicit ID.
+- `New` applies key and occurred-at options.
+- `New` copies headers on input.
+- `Headers` returns a copy.
+- `KindOf` returns the protobuf full name.
+
+Router tests:
+
+- `Subscribe` rejects nil handlers.
+- `Subscribe` rejects handlers with no listened kinds.
+- `Handle` returns `ErrUnhandledKind` when no handler matches.
+- `Handle` calls matching handlers in subscription order.
+- `Handle` does not call handlers for other kinds.
+- `Handle` stops and returns the first handler error.
+
+Interface conformance tests:
+
+- router implements `Subscriber`.
+- handler fakes can be used with router without broker-specific message types.
+
+## Open Non-Goals
+
+These are explicitly outside this implementation:
+
+- transactional outbox store
+- outbox relay
+- database schema or migrations
+- retry, delay, dead-letter, or durable failure policy
+- concrete Kafka, RabbitMQ, NATS, or other broker adapters
+- ConnectRPC handler/client generation
+- cross-language schema governance beyond protobuf message naming
+- generic typed handlers
+- replacing or modifying `ddd/event`
+

--- a/docs/superpowers/specs/2026-05-10-integration-message-design.md
+++ b/docs/superpowers/specs/2026-05-10-integration-message-design.md
@@ -390,4 +390,3 @@ These are explicitly outside this implementation:
 - cross-language schema governance beyond protobuf message naming
 - generic typed handlers
 - replacing or modifying `ddd/event`
-


### PR DESCRIPTION
## Summary

- Add `ddd/message` with a protobuf-first `Message` struct, construction options, metadata accessors, and `KindOf` helper.
- Add integration messaging interfaces (`Publisher`, `Subscriber`, `Handler`) plus a deterministic `Router` for kind-based handler dispatch.
- Document the non-transactional integration messaging design and update project knowledge for the new DDD message package.

## Test Plan

- `go test ./...`
- `make test`
- `git diff --check 6ee3738..HEAD`
- Project knowledge verify via `superpowers-memory:update` verifier