### PR TITLE
Add DDD integration message and outbox primitives

### DIFF
--- a/ddd/message/outbox/codec.go
+++ b/ddd/message/outbox/codec.go
@@ -1,6 +1,7 @@
 package outbox
 
 import (
+	"reflect"
 	"sync"
 	"time"
 
@@ -36,7 +37,7 @@ func (c *ProtoCodec) Register(kind message.Kind, factory func() proto.Message) e
 }
 
 func (c *ProtoCodec) Encode(msg message.Message) (Record, error) {
-	if msg.Payload() == nil {
+	if isNilProtoMessage(msg.Payload()) {
 		return Record{}, message.ErrNilPayload
 	}
 	if msg.Kind() == "" {
@@ -73,7 +74,7 @@ func (c *ProtoCodec) Decode(record Record) (message.Message, error) {
 		return message.Message{}, ErrUnknownKind
 	}
 	payload := factory()
-	if payload == nil {
+	if isNilProtoMessage(payload) {
 		return message.Message{}, ErrNilFactory
 	}
 	if err := proto.Unmarshal(record.Payload, payload); err != nil {
@@ -87,4 +88,18 @@ func (c *ProtoCodec) Decode(record Record) (message.Message, error) {
 		message.WithOccurredAt(record.OccurredAt),
 		message.WithHeaders(record.Headers),
 	)
+}
+
+func isNilProtoMessage(payload proto.Message) bool {
+	if payload == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(payload)
+	switch value.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return value.IsNil()
+	default:
+		return false
+	}
 }

--- a/ddd/message/outbox/codec.go
+++ b/ddd/message/outbox/codec.go
@@ -1,0 +1,90 @@
+package outbox
+
+import (
+	"sync"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message"
+	"google.golang.org/protobuf/proto"
+)
+
+type Codec interface {
+	Encode(message.Message) (Record, error)
+	Decode(Record) (message.Message, error)
+}
+
+type ProtoCodec struct {
+	mu        sync.RWMutex
+	factories map[message.Kind]func() proto.Message
+}
+
+func NewProtoCodec() *ProtoCodec {
+	return &ProtoCodec{factories: make(map[message.Kind]func() proto.Message)}
+}
+
+func (c *ProtoCodec) Register(kind message.Kind, factory func() proto.Message) error {
+	if kind == "" {
+		return message.ErrEmptyKind
+	}
+	if factory == nil {
+		return ErrNilFactory
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.factories[kind] = factory
+	return nil
+}
+
+func (c *ProtoCodec) Encode(msg message.Message) (Record, error) {
+	if msg.Payload() == nil {
+		return Record{}, message.ErrNilPayload
+	}
+	if msg.Kind() == "" {
+		return Record{}, message.ErrEmptyKind
+	}
+	payload, err := proto.Marshal(msg.Payload())
+	if err != nil {
+		return Record{}, err
+	}
+	id, err := generateID()
+	if err != nil {
+		return Record{}, err
+	}
+	now := time.Now()
+	return Record{
+		ID:         id,
+		MessageID:  msg.ID(),
+		Kind:       msg.Kind(),
+		Key:        msg.Key(),
+		OccurredAt: msg.OccurredAt(),
+		Payload:    payload,
+		Headers:    msg.Headers(),
+		Status:     StatusPending,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}, nil
+}
+
+func (c *ProtoCodec) Decode(record Record) (message.Message, error) {
+	c.mu.RLock()
+	factory := c.factories[record.Kind]
+	c.mu.RUnlock()
+	if factory == nil {
+		return message.Message{}, ErrUnknownKind
+	}
+	payload := factory()
+	if payload == nil {
+		return message.Message{}, ErrNilFactory
+	}
+	if err := proto.Unmarshal(record.Payload, payload); err != nil {
+		return message.Message{}, err
+	}
+	return message.New(
+		record.Kind,
+		payload,
+		message.WithID(record.MessageID),
+		message.WithKey(record.Key),
+		message.WithOccurredAt(record.OccurredAt),
+		message.WithHeaders(record.Headers),
+	)
+}

--- a/ddd/message/outbox/codec_test.go
+++ b/ddd/message/outbox/codec_test.go
@@ -81,3 +81,61 @@ func TestProtoCodecRejectsNilPayload(t *testing.T) {
 
 	require.True(t, errors.Is(err, message.ErrNilPayload))
 }
+
+// A registered factory that returns nil must fail before protobuf decoding so
+// relay startup mistakes surface as outbox configuration errors.
+func TestProtoCodecRejectsNilFactoryOutput(t *testing.T) {
+	codec := outbox.NewProtoCodec()
+	require.NoError(t, codec.Register("test.test_model", func() proto.Message {
+		return nil
+	}))
+
+	_, err := codec.Decode(outbox.Record{
+		ID:        "record-1",
+		MessageID: "message-1",
+		Kind:      "test.test_model",
+		Payload:   []byte{},
+	})
+
+	require.True(t, errors.Is(err, outbox.ErrNilFactory))
+}
+
+// A typed-nil protobuf factory output must be rejected as a nil factory result
+// rather than reaching proto.Unmarshal and risking an adapter panic.
+func TestProtoCodecRejectsTypedNilFactoryOutput(t *testing.T) {
+	codec := outbox.NewProtoCodec()
+	require.NoError(t, codec.Register("test.test_model", func() proto.Message {
+		var payload *testdata.TestModel
+		return payload
+	}))
+
+	require.NotPanics(t, func() {
+		_, err := codec.Decode(outbox.Record{
+			ID:        "record-1",
+			MessageID: "message-1",
+			Kind:      "test.test_model",
+			Payload:   []byte{},
+		})
+		require.True(t, errors.Is(err, outbox.ErrNilFactory))
+	})
+}
+
+// Corrupt bytes for a registered kind must return the protobuf unmarshal error
+// so callers can distinguish schema or storage corruption from registration.
+func TestProtoCodecRejectsCorruptPayload(t *testing.T) {
+	codec := outbox.NewProtoCodec()
+	require.NoError(t, codec.Register("test.test_model", func() proto.Message {
+		return &testdata.TestModel{}
+	}))
+
+	_, err := codec.Decode(outbox.Record{
+		ID:        "record-1",
+		MessageID: "message-1",
+		Kind:      "test.test_model",
+		Payload:   []byte{0xff},
+	})
+
+	require.Error(t, err)
+	require.False(t, errors.Is(err, outbox.ErrNilFactory))
+	require.False(t, errors.Is(err, outbox.ErrUnknownKind))
+}

--- a/ddd/message/outbox/codec_test.go
+++ b/ddd/message/outbox/codec_test.go
@@ -1,0 +1,83 @@
+package outbox_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message"
+	"github.com/go-jimu/components/ddd/message/outbox"
+	testdata "github.com/go-jimu/components/encoding/testdata"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// ProtoCodec must round-trip the published protobuf contract and all message
+// metadata needed for idempotency, routing, and tracing.
+func TestProtoCodecRoundTrip(t *testing.T) {
+	codec := outbox.NewProtoCodec()
+	require.NoError(t, codec.Register("test.test_model", func() proto.Message {
+		return &testdata.TestModel{}
+	}))
+	occurredAt := time.Date(2026, 5, 10, 12, 30, 0, 0, time.UTC)
+	msg, err := message.New(
+		"test.test_model",
+		&testdata.TestModel{Id: 7, Name: "paid"},
+		message.WithID("message-1"),
+		message.WithKey("order-7"),
+		message.WithOccurredAt(occurredAt),
+		message.WithHeader("trace_id", "trace-1"),
+	)
+	require.NoError(t, err)
+
+	record, err := codec.Encode(msg)
+	require.NoError(t, err)
+	decoded, err := codec.Decode(record)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, record.ID)
+	require.Equal(t, "message-1", record.MessageID)
+	require.Equal(t, outbox.StatusPending, record.Status)
+	require.Equal(t, "message-1", decoded.ID())
+	require.Equal(t, message.Kind("test.test_model"), decoded.Kind())
+	require.Equal(t, "order-7", decoded.Key())
+	require.Equal(t, occurredAt, decoded.OccurredAt())
+	require.Equal(t, map[string]string{"trace_id": "trace-1"}, decoded.Headers())
+	require.True(t, proto.Equal(&testdata.TestModel{Id: 7, Name: "paid"}, decoded.Payload()))
+}
+
+// Invalid registry entries must fail before decode time so missing published
+// language registrations are caught near application startup.
+func TestProtoCodecRejectsInvalidRegistration(t *testing.T) {
+	codec := outbox.NewProtoCodec()
+
+	require.True(t, errors.Is(codec.Register("", func() proto.Message {
+		return &testdata.TestModel{}
+	}), message.ErrEmptyKind))
+	require.True(t, errors.Is(codec.Register("test.test_model", nil), outbox.ErrNilFactory))
+}
+
+// Unknown kinds must be rejected because the relay cannot reconstruct the
+// protobuf payload without a registered factory.
+func TestProtoCodecRejectsUnknownKind(t *testing.T) {
+	codec := outbox.NewProtoCodec()
+
+	_, err := codec.Decode(outbox.Record{
+		ID:        "record-1",
+		MessageID: "message-1",
+		Kind:      "missing.kind",
+		Payload:   []byte{1, 2, 3},
+	})
+
+	require.True(t, errors.Is(err, outbox.ErrUnknownKind))
+}
+
+// Encoding an absent protobuf payload must fail instead of producing an
+// unpublishable outbox record.
+func TestProtoCodecRejectsNilPayload(t *testing.T) {
+	codec := outbox.NewProtoCodec()
+
+	_, err := codec.Encode(message.Message{})
+
+	require.True(t, errors.Is(err, message.ErrNilPayload))
+}

--- a/ddd/message/outbox/doc.go
+++ b/ddd/message/outbox/doc.go
@@ -3,5 +3,5 @@
 //
 // Record messages through Recorder inside the same transaction as the business
 // write. Publish them through Relay after commit. Delivery is at-least-once, so
-// consumers must deduplicate by message.Message.ID.
+// consumers must deduplicate by the message ID.
 package outbox

--- a/ddd/message/outbox/doc.go
+++ b/ddd/message/outbox/doc.go
@@ -1,0 +1,7 @@
+// Package outbox provides transaction-time recording and relay primitives for
+// reliable integration message publishing.
+//
+// Record messages through Recorder inside the same transaction as the business
+// write. Publish them through Relay after commit. Delivery is at-least-once, so
+// consumers must deduplicate by message.Message.ID.
+package outbox

--- a/ddd/message/outbox/errors.go
+++ b/ddd/message/outbox/errors.go
@@ -1,0 +1,13 @@
+package outbox
+
+import "errors"
+
+var (
+	ErrNilStore            = errors.New("outbox: nil store")
+	ErrNilCodec            = errors.New("outbox: nil codec")
+	ErrNilPublisher        = errors.New("outbox: nil publisher")
+	ErrInvalidClaimOptions = errors.New("outbox: invalid claim options")
+	ErrInvalidRunOptions   = errors.New("outbox: invalid run options")
+	ErrUnknownKind         = errors.New("outbox: unknown message kind")
+	ErrNilFactory          = errors.New("outbox: nil protobuf factory")
+)

--- a/ddd/message/outbox/record.go
+++ b/ddd/message/outbox/record.go
@@ -52,7 +52,7 @@ func cloneBytes(src []byte) []byte {
 }
 
 func cloneHeaders(headers map[string]string) map[string]string {
-	if len(headers) == 0 {
+	if headers == nil {
 		return nil
 	}
 	copied := make(map[string]string, len(headers))

--- a/ddd/message/outbox/record.go
+++ b/ddd/message/outbox/record.go
@@ -1,0 +1,71 @@
+package outbox
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message"
+)
+
+type Status string
+
+const (
+	StatusPending    Status = "pending"
+	StatusProcessing Status = "processing"
+	StatusPublished  Status = "published"
+	StatusFailed     Status = "failed"
+)
+
+type Record struct {
+	ID         string
+	MessageID  string
+	Kind       message.Kind
+	Key        string
+	OccurredAt time.Time
+	Payload    []byte
+	Headers    map[string]string
+
+	Status        Status
+	Attempts      int
+	NextAttemptAt time.Time
+	LockedUntil   time.Time
+	ClaimedBy     string
+	LastError     string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+func (r Record) Clone() Record {
+	r.Payload = cloneBytes(r.Payload)
+	r.Headers = cloneHeaders(r.Headers)
+	return r
+}
+
+func cloneBytes(src []byte) []byte {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]byte, len(src))
+	copy(dst, src)
+	return dst
+}
+
+func cloneHeaders(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(headers))
+	for key, value := range headers {
+		copied[key] = value
+	}
+	return copied
+}
+
+func generateID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}

--- a/ddd/message/outbox/record_test.go
+++ b/ddd/message/outbox/record_test.go
@@ -31,3 +31,17 @@ func TestRecordCloneCopiesMutableFields(t *testing.T) {
 	require.Equal(t, map[string]string{"tenant": "tenant-a"}, original.Headers)
 	require.Equal(t, "record-1", cloned.ID)
 }
+
+// Clone must preserve a non-nil empty headers map so callers can add headers to
+// the clone without mutating the source record or panicking on assignment.
+func TestRecordClonePreservesEmptyHeadersMap(t *testing.T) {
+	original := outbox.Record{
+		Headers: map[string]string{},
+	}
+
+	cloned := original.Clone()
+	cloned.Headers["tenant"] = "tenant-a"
+
+	require.Empty(t, original.Headers)
+	require.Equal(t, map[string]string{"tenant": "tenant-a"}, cloned.Headers)
+}

--- a/ddd/message/outbox/record_test.go
+++ b/ddd/message/outbox/record_test.go
@@ -1,0 +1,33 @@
+package outbox_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message"
+	"github.com/go-jimu/components/ddd/message/outbox"
+	"github.com/stretchr/testify/require"
+)
+
+// Clone must copy mutable payload and header data so store implementations can
+// hand records to callers without exposing shared mutation.
+func TestRecordCloneCopiesMutableFields(t *testing.T) {
+	original := outbox.Record{
+		ID:         "record-1",
+		MessageID:  "message-1",
+		Kind:       message.Kind("test.test_model"),
+		Key:        "order-1",
+		OccurredAt: time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC),
+		Payload:    []byte{1, 2, 3},
+		Headers:    map[string]string{"tenant": "tenant-a"},
+		Status:     outbox.StatusPending,
+	}
+
+	cloned := original.Clone()
+	cloned.Payload[0] = 9
+	cloned.Headers["tenant"] = "tenant-b"
+
+	require.Equal(t, []byte{1, 2, 3}, original.Payload)
+	require.Equal(t, map[string]string{"tenant": "tenant-a"}, original.Headers)
+	require.Equal(t, "record-1", cloned.ID)
+}

--- a/ddd/message/outbox/recorder.go
+++ b/ddd/message/outbox/recorder.go
@@ -1,0 +1,51 @@
+package outbox
+
+import (
+	"context"
+
+	"github.com/go-jimu/components/ddd/message"
+)
+
+type Recorder interface {
+	Record(ctx context.Context, messages ...message.Message) error
+}
+
+type RecorderOption func(*recorderConfig)
+
+type recorderConfig struct{}
+
+type StoreRecorder struct {
+	store Store
+	codec Codec
+}
+
+func NewRecorder(store Store, codec Codec, opts ...RecorderOption) (*StoreRecorder, error) {
+	if store == nil {
+		return nil, ErrNilStore
+	}
+	if codec == nil {
+		return nil, ErrNilCodec
+	}
+	cfg := recorderConfig{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return &StoreRecorder{store: store, codec: codec}, nil
+}
+
+func (r *StoreRecorder) Record(ctx context.Context, messages ...message.Message) error {
+	if len(messages) == 0 {
+		return nil
+	}
+	records := make([]Record, 0, len(messages))
+	for _, msg := range messages {
+		record, err := r.codec.Encode(msg)
+		if err != nil {
+			return err
+		}
+		records = append(records, record)
+	}
+	return r.store.Append(ctx, records...)
+}

--- a/ddd/message/outbox/recorder_test.go
+++ b/ddd/message/outbox/recorder_test.go
@@ -29,6 +29,73 @@ func TestRecorderRecordsMessagesThroughStore(t *testing.T) {
 	require.Equal(t, outbox.StatusPending, store.appended[0].Status)
 }
 
+// Empty recorder input must be a no-op so callers can pass drained batches
+// without creating empty store writes.
+func TestRecorderRecordEmptyInputDoesNotAppend(t *testing.T) {
+	store := &fakeStore{}
+	recorder, err := outbox.NewRecorder(store, &fakeCodec{})
+	require.NoError(t, err)
+
+	require.NoError(t, recorder.Record(context.Background()))
+
+	require.Zero(t, store.appendCalls)
+	require.Empty(t, store.appended)
+}
+
+// Recorder must append a complete encoded batch in one Store call so the store
+// boundary can own transaction-time persistence for the whole batch.
+func TestRecorderAppendsMultipleMessagesAsSingleBatch(t *testing.T) {
+	msg1, err := message.New("test.first", &testdata.TestModel{}, message.WithID("message-1"))
+	require.NoError(t, err)
+	msg2, err := message.New("test.second", &testdata.TestModel{}, message.WithID("message-2"))
+	require.NoError(t, err)
+	store := &fakeStore{}
+	recorder, err := outbox.NewRecorder(store, &fakeCodec{
+		records: []outbox.Record{
+			{MessageID: "message-1", Status: outbox.StatusPending},
+			{MessageID: "message-2", Status: outbox.StatusPending},
+		},
+	})
+	require.NoError(t, err)
+
+	require.NoError(t, recorder.Record(context.Background(), msg1, msg2))
+
+	require.Equal(t, 1, store.appendCalls)
+	require.Len(t, store.appended, 2)
+	require.Len(t, store.batches, 1)
+	require.Equal(t, []outbox.Record{
+		{MessageID: "message-1", Status: outbox.StatusPending},
+		{MessageID: "message-2", Status: outbox.StatusPending},
+	}, store.batches[0])
+}
+
+// If encoding any message fails, Recorder must return that error without
+// appending a partial batch to the Store.
+func TestRecorderRecordEncodeFailureDoesNotPartiallyAppend(t *testing.T) {
+	encodeErr := errors.New("encode failed")
+	msg1, err := message.New("test.first", &testdata.TestModel{}, message.WithID("message-1"))
+	require.NoError(t, err)
+	msg2, err := message.New("test.second", &testdata.TestModel{}, message.WithID("message-2"))
+	require.NoError(t, err)
+	store := &fakeStore{}
+	codec := &fakeCodec{
+		records: []outbox.Record{
+			{MessageID: "message-1", Status: outbox.StatusPending},
+		},
+		failAt: 2,
+		err:    encodeErr,
+	}
+	recorder, err := outbox.NewRecorder(store, codec)
+	require.NoError(t, err)
+
+	err = recorder.Record(context.Background(), msg1, msg2)
+
+	require.ErrorIs(t, err, encodeErr)
+	require.Equal(t, 2, codec.encodeCalls)
+	require.Zero(t, store.appendCalls)
+	require.Empty(t, store.appended)
+}
+
 // Recorder construction must reject missing collaborators so transaction-time
 // recording cannot silently drop messages.
 func TestNewRecorderRejectsMissingCollaborators(t *testing.T) {
@@ -40,11 +107,15 @@ func TestNewRecorderRejectsMissingCollaborators(t *testing.T) {
 }
 
 type fakeStore struct {
-	appended []outbox.Record
+	appendCalls int
+	appended    []outbox.Record
+	batches     [][]outbox.Record
 }
 
 func (s *fakeStore) Append(_ context.Context, records ...outbox.Record) error {
+	s.appendCalls++
 	s.appended = append(s.appended, records...)
+	s.batches = append(s.batches, append([]outbox.Record(nil), records...))
 	return nil
 }
 
@@ -58,4 +129,26 @@ func (s *fakeStore) MarkPublished(context.Context, ...string) error {
 
 func (s *fakeStore) MarkFailed(context.Context, string, string, time.Time) error {
 	return nil
+}
+
+type fakeCodec struct {
+	records     []outbox.Record
+	failAt      int
+	err         error
+	encodeCalls int
+}
+
+func (c *fakeCodec) Encode(msg message.Message) (outbox.Record, error) {
+	c.encodeCalls++
+	if c.failAt == c.encodeCalls {
+		return outbox.Record{}, c.err
+	}
+	if len(c.records) >= c.encodeCalls {
+		return c.records[c.encodeCalls-1], nil
+	}
+	return outbox.Record{MessageID: msg.ID(), Status: outbox.StatusPending}, nil
+}
+
+func (c *fakeCodec) Decode(outbox.Record) (message.Message, error) {
+	return message.Message{}, nil
 }

--- a/ddd/message/outbox/recorder_test.go
+++ b/ddd/message/outbox/recorder_test.go
@@ -1,0 +1,61 @@
+package outbox_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message"
+	"github.com/go-jimu/components/ddd/message/outbox"
+	testdata "github.com/go-jimu/components/encoding/testdata"
+	"github.com/stretchr/testify/require"
+)
+
+// Recorder must append encoded records through Store without publishing
+// anything, preserving transaction-time responsibility at the store boundary.
+func TestRecorderRecordsMessagesThroughStore(t *testing.T) {
+	codec := outbox.NewProtoCodec()
+	msg, err := message.New("test.test_model", &testdata.TestModel{}, message.WithID("message-1"))
+	require.NoError(t, err)
+	store := &fakeStore{}
+	recorder, err := outbox.NewRecorder(store, codec)
+	require.NoError(t, err)
+
+	require.NoError(t, recorder.Record(context.Background(), msg))
+
+	require.Len(t, store.appended, 1)
+	require.Equal(t, "message-1", store.appended[0].MessageID)
+	require.Equal(t, outbox.StatusPending, store.appended[0].Status)
+}
+
+// Recorder construction must reject missing collaborators so transaction-time
+// recording cannot silently drop messages.
+func TestNewRecorderRejectsMissingCollaborators(t *testing.T) {
+	_, err := outbox.NewRecorder(nil, outbox.NewProtoCodec())
+	require.True(t, errors.Is(err, outbox.ErrNilStore))
+
+	_, err = outbox.NewRecorder(&fakeStore{}, nil)
+	require.True(t, errors.Is(err, outbox.ErrNilCodec))
+}
+
+type fakeStore struct {
+	appended []outbox.Record
+}
+
+func (s *fakeStore) Append(_ context.Context, records ...outbox.Record) error {
+	s.appended = append(s.appended, records...)
+	return nil
+}
+
+func (s *fakeStore) Claim(context.Context, outbox.ClaimOptions) ([]outbox.Record, error) {
+	return nil, nil
+}
+
+func (s *fakeStore) MarkPublished(context.Context, ...string) error {
+	return nil
+}
+
+func (s *fakeStore) MarkFailed(context.Context, string, string, time.Time) error {
+	return nil
+}

--- a/ddd/message/outbox/recorder_test.go
+++ b/ddd/message/outbox/recorder_test.go
@@ -123,11 +123,11 @@ func (s *fakeStore) Claim(context.Context, outbox.ClaimOptions) ([]outbox.Record
 	return nil, nil
 }
 
-func (s *fakeStore) MarkPublished(context.Context, ...string) error {
+func (s *fakeStore) MarkPublished(context.Context, ...outbox.Record) error {
 	return nil
 }
 
-func (s *fakeStore) MarkFailed(context.Context, string, string, time.Time) error {
+func (s *fakeStore) MarkFailed(context.Context, outbox.Record, string, time.Time) error {
 	return nil
 }
 

--- a/ddd/message/outbox/relay.go
+++ b/ddd/message/outbox/relay.go
@@ -68,6 +68,36 @@ type RunResult struct {
 	Errors []error
 }
 
+type RunOptions struct {
+	Claim    ClaimOptions
+	Interval time.Duration
+	OnResult func(RunResult)
+}
+
+func (r *Relay) Run(ctx context.Context, opts RunOptions) error {
+	if opts.Interval <= 0 {
+		return ErrInvalidRunOptions
+	}
+	for {
+		result := r.RunOnce(ctx, opts.Claim)
+		if opts.OnResult != nil {
+			opts.OnResult(result)
+		}
+		timer := time.NewTimer(opts.Interval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
 func (r *Relay) RunOnce(ctx context.Context, opts ClaimOptions) RunResult {
 	opts, err := opts.normalize(r.now)
 	if err != nil {

--- a/ddd/message/outbox/relay.go
+++ b/ddd/message/outbox/relay.go
@@ -79,6 +79,9 @@ func (r *Relay) Run(ctx context.Context, opts RunOptions) error {
 		return ErrInvalidRunOptions
 	}
 	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		result := r.RunOnce(ctx, opts.Claim)
 		if opts.OnResult != nil {
 			opts.OnResult(result)

--- a/ddd/message/outbox/relay.go
+++ b/ddd/message/outbox/relay.go
@@ -102,7 +102,7 @@ func (r *Relay) Run(ctx context.Context, opts RunOptions) error {
 }
 
 func (r *Relay) RunOnce(ctx context.Context, opts ClaimOptions) RunResult {
-	opts, err := opts.normalize(r.now)
+	opts, err := NormalizeClaimOptions(opts, r.now)
 	if err != nil {
 		return RunResult{Errors: []error{fmt.Errorf("normalize claim options: %w", err)}}
 	}
@@ -121,7 +121,7 @@ func (r *Relay) RunOnce(ctx context.Context, opts ClaimOptions) RunResult {
 			r.markFailed(ctx, &result, record, err)
 			continue
 		}
-		if err := r.store.MarkPublished(ctx, record.ID); err != nil {
+		if err := r.store.MarkPublished(ctx, record); err != nil {
 			result.Errors = append(result.Errors, fmt.Errorf("mark published record %s: %w", record.ID, err))
 			continue
 		}
@@ -136,7 +136,7 @@ func (r *Relay) markFailed(ctx context.Context, result *RunResult, record Record
 	if decision.Retry {
 		nextAttemptAt = decision.NextAttemptAt
 	}
-	if err := r.store.MarkFailed(ctx, record.ID, decision.Reason, nextAttemptAt); err != nil {
+	if err := r.store.MarkFailed(ctx, record, decision.Reason, nextAttemptAt); err != nil {
 		result.Errors = append(result.Errors, fmt.Errorf(
 			"mark failed record %s after processing error %q: %w",
 			record.ID,

--- a/ddd/message/outbox/relay.go
+++ b/ddd/message/outbox/relay.go
@@ -1,0 +1,107 @@
+package outbox
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message"
+)
+
+type Relay struct {
+	store     Store
+	codec     Codec
+	publisher message.Publisher
+	retry     RetryPolicy
+	now       func() time.Time
+}
+
+type relayConfig struct {
+	retry RetryPolicy
+	now   func() time.Time
+}
+
+type RelayOption func(*relayConfig)
+
+func WithRetryPolicy(policy RetryPolicy) RelayOption {
+	return func(cfg *relayConfig) {
+		if policy != nil {
+			cfg.retry = policy
+		}
+	}
+}
+
+func WithClock(now func() time.Time) RelayOption {
+	return func(cfg *relayConfig) {
+		if now != nil {
+			cfg.now = now
+		}
+	}
+}
+
+func NewRelay(store Store, codec Codec, publisher message.Publisher, opts ...RelayOption) (*Relay, error) {
+	if store == nil {
+		return nil, ErrNilStore
+	}
+	if codec == nil {
+		return nil, ErrNilCodec
+	}
+	if publisher == nil {
+		return nil, ErrNilPublisher
+	}
+	cfg := relayConfig{retry: NoRetryPolicy{}, now: time.Now}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return &Relay{store: store, codec: codec, publisher: publisher, retry: cfg.retry, now: cfg.now}, nil
+}
+
+type RunResult struct {
+	Claimed   int
+	Published int
+	Failed    int
+	Errors    []error
+}
+
+func (r *Relay) RunOnce(ctx context.Context, opts ClaimOptions) RunResult {
+	opts, err := opts.normalize(r.now)
+	if err != nil {
+		return RunResult{Errors: []error{err}}
+	}
+	records, err := r.store.Claim(ctx, opts)
+	if err != nil {
+		return RunResult{Errors: []error{err}}
+	}
+	result := RunResult{Claimed: len(records)}
+	for _, record := range records {
+		msg, err := r.codec.Decode(record)
+		if err != nil {
+			r.markFailed(ctx, &result, record, err)
+			continue
+		}
+		if err := r.publisher.Publish(ctx, msg); err != nil {
+			r.markFailed(ctx, &result, record, err)
+			continue
+		}
+		if err := r.store.MarkPublished(ctx, record.ID); err != nil {
+			result.Errors = append(result.Errors, err)
+			continue
+		}
+		result.Published++
+	}
+	return result
+}
+
+func (r *Relay) markFailed(ctx context.Context, result *RunResult, record Record, cause error) {
+	decision := r.retry.NextAttempt(record, cause, r.now())
+	nextAttemptAt := time.Time{}
+	if decision.Retry {
+		nextAttemptAt = decision.NextAttemptAt
+	}
+	if err := r.store.MarkFailed(ctx, record.ID, decision.Reason, nextAttemptAt); err != nil {
+		result.Errors = append(result.Errors, err)
+		return
+	}
+	result.Failed++
+}

--- a/ddd/message/outbox/relay.go
+++ b/ddd/message/outbox/relay.go
@@ -2,6 +2,8 @@ package outbox
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/go-jimu/components/ddd/message"
@@ -60,18 +62,20 @@ func NewRelay(store Store, codec Codec, publisher message.Publisher, opts ...Rel
 type RunResult struct {
 	Claimed   int
 	Published int
-	Failed    int
-	Errors    []error
+	// Failed counts decode or publish failures that were successfully persisted
+	// through Store.MarkFailed.
+	Failed int
+	Errors []error
 }
 
 func (r *Relay) RunOnce(ctx context.Context, opts ClaimOptions) RunResult {
 	opts, err := opts.normalize(r.now)
 	if err != nil {
-		return RunResult{Errors: []error{err}}
+		return RunResult{Errors: []error{fmt.Errorf("normalize claim options: %w", err)}}
 	}
 	records, err := r.store.Claim(ctx, opts)
 	if err != nil {
-		return RunResult{Errors: []error{err}}
+		return RunResult{Errors: []error{fmt.Errorf("claim outbox records: %w", err)}}
 	}
 	result := RunResult{Claimed: len(records)}
 	for _, record := range records {
@@ -85,7 +89,7 @@ func (r *Relay) RunOnce(ctx context.Context, opts ClaimOptions) RunResult {
 			continue
 		}
 		if err := r.store.MarkPublished(ctx, record.ID); err != nil {
-			result.Errors = append(result.Errors, err)
+			result.Errors = append(result.Errors, fmt.Errorf("mark published record %s: %w", record.ID, err))
 			continue
 		}
 		result.Published++
@@ -100,7 +104,12 @@ func (r *Relay) markFailed(ctx context.Context, result *RunResult, record Record
 		nextAttemptAt = decision.NextAttemptAt
 	}
 	if err := r.store.MarkFailed(ctx, record.ID, decision.Reason, nextAttemptAt); err != nil {
-		result.Errors = append(result.Errors, err)
+		result.Errors = append(result.Errors, fmt.Errorf(
+			"mark failed record %s after processing error %q: %w",
+			record.ID,
+			cause.Error(),
+			errors.Join(cause, err),
+		))
 		return
 	}
 	result.Failed++

--- a/ddd/message/outbox/relay_test.go
+++ b/ddd/message/outbox/relay_test.go
@@ -62,7 +62,10 @@ func TestRelayRunOnceRetriesPublishFailure(t *testing.T) {
 
 	result := relay.RunOnce(context.Background(), validClaimOptions())
 
+	require.Equal(t, 1, result.Claimed)
+	require.Zero(t, result.Published)
 	require.Equal(t, 1, result.Failed)
+	require.Empty(t, result.Errors)
 	require.Equal(t, fixedClock().Add(time.Minute), store.failed[0].nextAttemptAt)
 	require.Equal(t, "broker unavailable", store.failed[0].reason)
 }
@@ -79,7 +82,130 @@ func TestRelayRunOnceReportsMarkPublishedFailure(t *testing.T) {
 	require.Equal(t, 1, result.Claimed)
 	require.Zero(t, result.Published)
 	require.Len(t, result.Errors, 1)
+	require.Contains(t, result.Errors[0].Error(), "mark published record record-1")
 	require.Contains(t, result.Errors[0].Error(), "db down")
+}
+
+// Claim failures must include operation context and stop before any record-level
+// work is attempted.
+func TestRelayRunOnceReportsClaimFailure(t *testing.T) {
+	store := &relayStore{claimErr: errors.New("database timeout")}
+	relay, err := outbox.NewRelay(store, registeredCodec(t), &relayPublisher{}, outbox.WithClock(fixedClock))
+	require.NoError(t, err)
+
+	result := relay.RunOnce(context.Background(), validClaimOptions())
+
+	require.Zero(t, result.Claimed)
+	require.Zero(t, result.Published)
+	require.Zero(t, result.Failed)
+	require.Len(t, result.Errors, 1)
+	require.Contains(t, result.Errors[0].Error(), "claim outbox records")
+	require.Contains(t, result.Errors[0].Error(), "database timeout")
+}
+
+// Invalid claim options must preserve the sentinel error so callers can detect
+// caller-side configuration mistakes.
+func TestRelayRunOnceReportsInvalidClaimOptions(t *testing.T) {
+	relay, err := outbox.NewRelay(&relayStore{}, registeredCodec(t), &relayPublisher{}, outbox.WithClock(fixedClock))
+	require.NoError(t, err)
+
+	result := relay.RunOnce(context.Background(), outbox.ClaimOptions{})
+
+	require.Len(t, result.Errors, 1)
+	require.ErrorIs(t, result.Errors[0], outbox.ErrInvalidClaimOptions)
+}
+
+// Failed count means the original decode or publish failure was successfully
+// persisted through MarkFailed; MarkFailed persistence errors must preserve both
+// the original cause and the mark failure.
+func TestRelayRunOnceReportsMarkFailedFailureWithCause(t *testing.T) {
+	publishErr := errors.New("broker unavailable")
+	markFailedErr := errors.New("write failed")
+	store := &relayStore{claimed: []outbox.Record{validRecord(t)}, markFailedErr: markFailedErr}
+	publisher := &relayPublisher{err: publishErr}
+	relay, err := outbox.NewRelay(store, registeredCodec(t), publisher, outbox.WithClock(fixedClock))
+	require.NoError(t, err)
+
+	result := relay.RunOnce(context.Background(), validClaimOptions())
+
+	require.Equal(t, 1, result.Claimed)
+	require.Zero(t, result.Published)
+	require.Zero(t, result.Failed)
+	require.Len(t, result.Errors, 1)
+	require.Contains(t, result.Errors[0].Error(), "mark failed record record-1")
+	require.Contains(t, result.Errors[0].Error(), "broker unavailable")
+	require.Contains(t, result.Errors[0].Error(), "write failed")
+	require.ErrorIs(t, result.Errors[0], publishErr)
+	require.ErrorIs(t, result.Errors[0], markFailedErr)
+}
+
+// NewRelay must reject missing collaborators so RunOnce never panics on nil
+// store, codec, or publisher dependencies.
+func TestNewRelayRejectsNilDependencies(t *testing.T) {
+	store := &relayStore{}
+	codec := registeredCodec(t)
+	publisher := &relayPublisher{}
+
+	_, err := outbox.NewRelay(nil, codec, publisher)
+	require.ErrorIs(t, err, outbox.ErrNilStore)
+
+	_, err = outbox.NewRelay(store, nil, publisher)
+	require.ErrorIs(t, err, outbox.ErrNilCodec)
+
+	_, err = outbox.NewRelay(store, codec, nil)
+	require.ErrorIs(t, err, outbox.ErrNilPublisher)
+}
+
+// Nil relay options must be ignored so callers can compose optional
+// configuration without changing default relay behavior.
+func TestNewRelayIgnoresNilOption(t *testing.T) {
+	store := &relayStore{claimed: []outbox.Record{validRecord(t)}}
+	relay, err := outbox.NewRelay(store, registeredCodec(t), &relayPublisher{}, nil, outbox.WithClock(fixedClock))
+	require.NoError(t, err)
+
+	result := relay.RunOnce(context.Background(), validClaimOptions())
+
+	require.Equal(t, 1, result.Published)
+	require.Empty(t, result.Errors)
+}
+
+// A nil retry policy option must keep the default no-retry behavior so failure
+// records are persisted without a next-attempt timestamp.
+func TestNewRelayNilRetryPolicyKeepsDefaultNoRetryPolicy(t *testing.T) {
+	store := &relayStore{claimed: []outbox.Record{validRecord(t)}}
+	publisher := &relayPublisher{err: errors.New("broker unavailable")}
+	relay, err := outbox.NewRelay(
+		store,
+		registeredCodec(t),
+		publisher,
+		outbox.WithClock(fixedClock),
+		outbox.WithRetryPolicy(nil),
+	)
+	require.NoError(t, err)
+
+	result := relay.RunOnce(context.Background(), validClaimOptions())
+
+	require.Equal(t, 1, result.Failed)
+	require.True(t, store.failed[0].nextAttemptAt.IsZero())
+}
+
+// A nil clock option must keep the default clock instead of replacing it with
+// nil and breaking claim normalization or retry decisions.
+func TestNewRelayNilClockKeepsDefaultClock(t *testing.T) {
+	now := time.Now().UTC()
+	store := &relayStore{claimed: []outbox.Record{validRecord(t)}}
+	relay, err := outbox.NewRelay(store, registeredCodec(t), &relayPublisher{}, outbox.WithClock(nil))
+	require.NoError(t, err)
+
+	result := relay.RunOnce(context.Background(), outbox.ClaimOptions{
+		Limit:       10,
+		Now:         now,
+		LockedUntil: now.Add(time.Minute),
+		ClaimedBy:   "worker-1",
+	})
+
+	require.Equal(t, 1, result.Published)
+	require.Empty(t, result.Errors)
 }
 
 type relayStore struct {

--- a/ddd/message/outbox/relay_test.go
+++ b/ddd/message/outbox/relay_test.go
@@ -29,6 +29,7 @@ func TestRelayRunOncePublishesAndMarksPublished(t *testing.T) {
 	require.Empty(t, result.Errors)
 	require.Len(t, publisher.messages, 1)
 	require.Equal(t, []string{"record-1"}, store.published)
+	require.Equal(t, fixedClock(), store.claimOptions[0].Now)
 }
 
 // Decode failures must be persisted through MarkFailed so corrupted records do
@@ -269,6 +270,7 @@ func TestNewRelayNilClockKeepsDefaultClock(t *testing.T) {
 type relayStore struct {
 	claimed          []outbox.Record
 	claimCalls       int
+	claimOptions     []outbox.ClaimOptions
 	claimErr         error
 	markPublishedErr error
 	markFailedErr    error
@@ -283,25 +285,28 @@ type failedRecord struct {
 }
 
 func (s *relayStore) Append(context.Context, ...outbox.Record) error { return nil }
-func (s *relayStore) Claim(context.Context, outbox.ClaimOptions) ([]outbox.Record, error) {
+func (s *relayStore) Claim(_ context.Context, opts outbox.ClaimOptions) ([]outbox.Record, error) {
 	s.claimCalls++
+	s.claimOptions = append(s.claimOptions, opts)
 	if s.claimErr != nil {
 		return nil, s.claimErr
 	}
 	return s.claimed, nil
 }
-func (s *relayStore) MarkPublished(_ context.Context, ids ...string) error {
+func (s *relayStore) MarkPublished(_ context.Context, records ...outbox.Record) error {
 	if s.markPublishedErr != nil {
 		return s.markPublishedErr
 	}
-	s.published = append(s.published, ids...)
+	for _, record := range records {
+		s.published = append(s.published, record.ID)
+	}
 	return nil
 }
-func (s *relayStore) MarkFailed(_ context.Context, id string, reason string, nextAttemptAt time.Time) error {
+func (s *relayStore) MarkFailed(_ context.Context, record outbox.Record, reason string, nextAttemptAt time.Time) error {
 	if s.markFailedErr != nil {
 		return s.markFailedErr
 	}
-	s.failed = append(s.failed, failedRecord{id: id, reason: reason, nextAttemptAt: nextAttemptAt})
+	s.failed = append(s.failed, failedRecord{id: record.ID, reason: reason, nextAttemptAt: nextAttemptAt})
 	return nil
 }
 

--- a/ddd/message/outbox/relay_test.go
+++ b/ddd/message/outbox/relay_test.go
@@ -112,6 +112,7 @@ func TestRelayRunOnceReportsInvalidClaimOptions(t *testing.T) {
 	result := relay.RunOnce(context.Background(), outbox.ClaimOptions{})
 
 	require.Len(t, result.Errors, 1)
+	require.Contains(t, result.Errors[0].Error(), "normalize claim options")
 	require.ErrorIs(t, result.Errors[0], outbox.ErrInvalidClaimOptions)
 }
 

--- a/ddd/message/outbox/relay_test.go
+++ b/ddd/message/outbox/relay_test.go
@@ -1,0 +1,171 @@
+package outbox_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message"
+	"github.com/go-jimu/components/ddd/message/outbox"
+	testdata "github.com/go-jimu/components/encoding/testdata"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// Relay must publish claimed records and mark successful records as published so
+// they are not claimed again.
+func TestRelayRunOncePublishesAndMarksPublished(t *testing.T) {
+	store := &relayStore{claimed: []outbox.Record{validRecord(t)}}
+	codec := registeredCodec(t)
+	publisher := &relayPublisher{}
+	relay, err := outbox.NewRelay(store, codec, publisher, outbox.WithClock(fixedClock))
+	require.NoError(t, err)
+
+	result := relay.RunOnce(context.Background(), validClaimOptions())
+
+	require.Equal(t, 1, result.Claimed)
+	require.Equal(t, 1, result.Published)
+	require.Empty(t, result.Errors)
+	require.Len(t, publisher.messages, 1)
+	require.Equal(t, []string{"record-1"}, store.published)
+}
+
+// Decode failures must be persisted through MarkFailed so corrupted records do
+// not disappear from operational visibility.
+func TestRelayRunOnceMarksDecodeFailure(t *testing.T) {
+	store := &relayStore{claimed: []outbox.Record{{ID: "record-1", MessageID: "message-1", Kind: "missing.kind", Attempts: 1}}}
+	relay, err := outbox.NewRelay(store, outbox.NewProtoCodec(), &relayPublisher{}, outbox.WithClock(fixedClock))
+	require.NoError(t, err)
+
+	result := relay.RunOnce(context.Background(), validClaimOptions())
+
+	require.Equal(t, 1, result.Claimed)
+	require.Equal(t, 1, result.Failed)
+	require.True(t, store.failed[0].nextAttemptAt.IsZero())
+	require.Contains(t, store.failed[0].reason, "unknown message kind")
+}
+
+// Publish failures must use the configured retry policy and persist the next
+// attempt time.
+func TestRelayRunOnceRetriesPublishFailure(t *testing.T) {
+	store := &relayStore{claimed: []outbox.Record{validRecord(t)}}
+	publisher := &relayPublisher{err: errors.New("broker unavailable")}
+	relay, err := outbox.NewRelay(
+		store,
+		registeredCodec(t),
+		publisher,
+		outbox.WithClock(fixedClock),
+		outbox.WithRetryPolicy(outbox.FixedBackoffPolicy{MaxAttempts: 3, Backoff: time.Minute}),
+	)
+	require.NoError(t, err)
+
+	result := relay.RunOnce(context.Background(), validClaimOptions())
+
+	require.Equal(t, 1, result.Failed)
+	require.Equal(t, fixedClock().Add(time.Minute), store.failed[0].nextAttemptAt)
+	require.Equal(t, "broker unavailable", store.failed[0].reason)
+}
+
+// MarkPublished failures must be reported because the message may be delivered
+// again after the processing lock expires.
+func TestRelayRunOnceReportsMarkPublishedFailure(t *testing.T) {
+	store := &relayStore{claimed: []outbox.Record{validRecord(t)}, markPublishedErr: errors.New("db down")}
+	relay, err := outbox.NewRelay(store, registeredCodec(t), &relayPublisher{}, outbox.WithClock(fixedClock))
+	require.NoError(t, err)
+
+	result := relay.RunOnce(context.Background(), validClaimOptions())
+
+	require.Equal(t, 1, result.Claimed)
+	require.Zero(t, result.Published)
+	require.Len(t, result.Errors, 1)
+	require.Contains(t, result.Errors[0].Error(), "db down")
+}
+
+type relayStore struct {
+	claimed          []outbox.Record
+	claimErr         error
+	markPublishedErr error
+	markFailedErr    error
+	published        []string
+	failed           []failedRecord
+}
+
+type failedRecord struct {
+	id            string
+	reason        string
+	nextAttemptAt time.Time
+}
+
+func (s *relayStore) Append(context.Context, ...outbox.Record) error { return nil }
+func (s *relayStore) Claim(context.Context, outbox.ClaimOptions) ([]outbox.Record, error) {
+	if s.claimErr != nil {
+		return nil, s.claimErr
+	}
+	return s.claimed, nil
+}
+func (s *relayStore) MarkPublished(_ context.Context, ids ...string) error {
+	if s.markPublishedErr != nil {
+		return s.markPublishedErr
+	}
+	s.published = append(s.published, ids...)
+	return nil
+}
+func (s *relayStore) MarkFailed(_ context.Context, id string, reason string, nextAttemptAt time.Time) error {
+	if s.markFailedErr != nil {
+		return s.markFailedErr
+	}
+	s.failed = append(s.failed, failedRecord{id: id, reason: reason, nextAttemptAt: nextAttemptAt})
+	return nil
+}
+
+type relayPublisher struct {
+	messages []message.Message
+	err      error
+}
+
+func (p *relayPublisher) Publish(_ context.Context, msg message.Message) error {
+	if p.err != nil {
+		return p.err
+	}
+	p.messages = append(p.messages, msg)
+	return nil
+}
+
+func fixedClock() time.Time {
+	return time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+}
+
+func validClaimOptions() outbox.ClaimOptions {
+	return outbox.ClaimOptions{
+		Limit:       10,
+		LockedUntil: fixedClock().Add(time.Minute),
+		ClaimedBy:   "worker-1",
+	}
+}
+
+func registeredCodec(t *testing.T) *outbox.ProtoCodec {
+	t.Helper()
+	codec := outbox.NewProtoCodec()
+	require.NoError(t, codec.Register("test.test_model", func() proto.Message {
+		return &testdata.TestModel{}
+	}))
+	return codec
+}
+
+func validRecord(t *testing.T) outbox.Record {
+	t.Helper()
+	msg, err := message.New(
+		"test.test_model",
+		&testdata.TestModel{Id: 7, Name: "paid"},
+		message.WithID("message-1"),
+		message.WithKey("order-7"),
+		message.WithOccurredAt(fixedClock()),
+	)
+	require.NoError(t, err)
+	record, err := registeredCodec(t).Encode(msg)
+	require.NoError(t, err)
+	record.ID = "record-1"
+	record.Attempts = 1
+	return record
+}

--- a/ddd/message/outbox/relay_test.go
+++ b/ddd/message/outbox/relay_test.go
@@ -116,6 +116,38 @@ func TestRelayRunOnceReportsInvalidClaimOptions(t *testing.T) {
 	require.ErrorIs(t, result.Errors[0], outbox.ErrInvalidClaimOptions)
 }
 
+// Run must reject non-positive intervals so callers do not accidentally create
+// tight loops.
+func TestRelayRunRejectsInvalidInterval(t *testing.T) {
+	relay, err := outbox.NewRelay(&relayStore{}, registeredCodec(t), &relayPublisher{})
+	require.NoError(t, err)
+
+	err = relay.Run(context.Background(), outbox.RunOptions{})
+
+	require.True(t, errors.Is(err, outbox.ErrInvalidRunOptions))
+}
+
+// Run must call RunOnce repeatedly and stop when the context is canceled.
+func TestRelayRunStopsOnContextCancellation(t *testing.T) {
+	store := &relayStore{}
+	relay, err := outbox.NewRelay(store, registeredCodec(t), &relayPublisher{}, outbox.WithClock(fixedClock))
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+
+	err = relay.Run(ctx, outbox.RunOptions{
+		Claim:    validClaimOptions(),
+		Interval: time.Millisecond,
+		OnResult: func(outbox.RunResult) {
+			calls++
+			cancel()
+		},
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, calls)
+}
+
 // Failed count means the original decode or publish failure was successfully
 // persisted through MarkFailed; MarkFailed persistence errors must preserve both
 // the original cause and the mark failure.

--- a/ddd/message/outbox/relay_test.go
+++ b/ddd/message/outbox/relay_test.go
@@ -152,7 +152,7 @@ func TestRelayRunAlreadyCanceledDoesNoWork(t *testing.T) {
 	require.Zero(t, results)
 }
 
-// Run must call RunOnce repeatedly and stop when the context is canceled.
+// Run must stop after an iteration when the context is canceled from OnResult.
 func TestRelayRunStopsOnContextCancellation(t *testing.T) {
 	store := &relayStore{}
 	relay, err := outbox.NewRelay(store, registeredCodec(t), &relayPublisher{}, outbox.WithClock(fixedClock))

--- a/ddd/message/outbox/relay_test.go
+++ b/ddd/message/outbox/relay_test.go
@@ -122,9 +122,34 @@ func TestRelayRunRejectsInvalidInterval(t *testing.T) {
 	relay, err := outbox.NewRelay(&relayStore{}, registeredCodec(t), &relayPublisher{})
 	require.NoError(t, err)
 
-	err = relay.Run(context.Background(), outbox.RunOptions{})
+	for _, interval := range []time.Duration{0, -time.Millisecond} {
+		err = relay.Run(context.Background(), outbox.RunOptions{Interval: interval})
 
-	require.True(t, errors.Is(err, outbox.ErrInvalidRunOptions))
+		require.True(t, errors.Is(err, outbox.ErrInvalidRunOptions))
+	}
+}
+
+// Run must stop before claiming records when the context is already canceled
+// so shutdown does not perform delivery side effects.
+func TestRelayRunAlreadyCanceledDoesNoWork(t *testing.T) {
+	store := &relayStore{claimed: []outbox.Record{validRecord(t)}}
+	relay, err := outbox.NewRelay(store, registeredCodec(t), &relayPublisher{}, outbox.WithClock(fixedClock))
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	results := 0
+
+	err = relay.Run(ctx, outbox.RunOptions{
+		Claim:    validClaimOptions(),
+		Interval: time.Millisecond,
+		OnResult: func(outbox.RunResult) {
+			results++
+		},
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Zero(t, store.claimCalls)
+	require.Zero(t, results)
 }
 
 // Run must call RunOnce repeatedly and stop when the context is canceled.
@@ -243,6 +268,7 @@ func TestNewRelayNilClockKeepsDefaultClock(t *testing.T) {
 
 type relayStore struct {
 	claimed          []outbox.Record
+	claimCalls       int
 	claimErr         error
 	markPublishedErr error
 	markFailedErr    error
@@ -258,6 +284,7 @@ type failedRecord struct {
 
 func (s *relayStore) Append(context.Context, ...outbox.Record) error { return nil }
 func (s *relayStore) Claim(context.Context, outbox.ClaimOptions) ([]outbox.Record, error) {
+	s.claimCalls++
 	if s.claimErr != nil {
 		return nil, s.claimErr
 	}

--- a/ddd/message/outbox/retry.go
+++ b/ddd/message/outbox/retry.go
@@ -29,7 +29,11 @@ func (p FixedBackoffPolicy) NextAttempt(record Record, err error, now time.Time)
 		return decision
 	}
 	decision.Retry = true
-	decision.NextAttemptAt = now.Add(p.Backoff)
+	if p.Backoff <= 0 {
+		decision.NextAttemptAt = now
+	} else {
+		decision.NextAttemptAt = now.Add(p.Backoff)
+	}
 	return decision
 }
 

--- a/ddd/message/outbox/retry.go
+++ b/ddd/message/outbox/retry.go
@@ -1,0 +1,41 @@
+package outbox
+
+import "time"
+
+type RetryPolicy interface {
+	NextAttempt(record Record, err error, now time.Time) RetryDecision
+}
+
+type RetryDecision struct {
+	Retry         bool
+	NextAttemptAt time.Time
+	Reason        string
+}
+
+type NoRetryPolicy struct{}
+
+func (NoRetryPolicy) NextAttempt(_ Record, err error, _ time.Time) RetryDecision {
+	return RetryDecision{Reason: errorReason(err)}
+}
+
+type FixedBackoffPolicy struct {
+	MaxAttempts int
+	Backoff     time.Duration
+}
+
+func (p FixedBackoffPolicy) NextAttempt(record Record, err error, now time.Time) RetryDecision {
+	decision := RetryDecision{Reason: errorReason(err)}
+	if p.MaxAttempts > 0 && record.Attempts >= p.MaxAttempts {
+		return decision
+	}
+	decision.Retry = true
+	decision.NextAttemptAt = now.Add(p.Backoff)
+	return decision
+}
+
+func errorReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/ddd/message/outbox/retry_test.go
+++ b/ddd/message/outbox/retry_test.go
@@ -83,9 +83,9 @@ func TestFixedBackoffPolicyWithZeroBackoffSchedulesAtNow(t *testing.T) {
 	require.Equal(t, "temporary", decision.Reason)
 }
 
-// FixedBackoffPolicy must preserve negative backoff durations so callers can
-// intentionally schedule retries before the relay clock time.
-func TestFixedBackoffPolicyWithNegativeBackoffSchedulesFromNow(t *testing.T) {
+// FixedBackoffPolicy must treat negative backoff as immediate retry scheduling
+// at the relay clock time.
+func TestFixedBackoffPolicyWithNegativeBackoffSchedulesAtNow(t *testing.T) {
 	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
 	backoff := -time.Minute
 	policy := outbox.FixedBackoffPolicy{MaxAttempts: 3, Backoff: backoff}
@@ -93,6 +93,6 @@ func TestFixedBackoffPolicyWithNegativeBackoffSchedulesFromNow(t *testing.T) {
 	decision := policy.NextAttempt(outbox.Record{Attempts: 1}, errors.New("temporary"), now)
 
 	require.True(t, decision.Retry)
-	require.Equal(t, now.Add(backoff), decision.NextAttemptAt)
+	require.Equal(t, now, decision.NextAttemptAt)
 	require.Equal(t, "temporary", decision.Reason)
 }

--- a/ddd/message/outbox/retry_test.go
+++ b/ddd/message/outbox/retry_test.go
@@ -1,0 +1,45 @@
+package outbox_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message/outbox"
+	"github.com/stretchr/testify/require"
+)
+
+// NoRetryPolicy must make failures terminal by default so relays do not create
+// unbounded retry loops unless callers choose a retry policy.
+func TestNoRetryPolicyReturnsTerminalDecision(t *testing.T) {
+	decision := outbox.NoRetryPolicy{}.NextAttempt(outbox.Record{}, errors.New("publish failed"), time.Now())
+
+	require.False(t, decision.Retry)
+	require.True(t, decision.NextAttemptAt.IsZero())
+	require.Equal(t, "publish failed", decision.Reason)
+}
+
+// FixedBackoffPolicy must retry below the max attempt count using the configured
+// delay from the relay clock.
+func TestFixedBackoffPolicyRetriesBelowMaxAttempts(t *testing.T) {
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	policy := outbox.FixedBackoffPolicy{MaxAttempts: 3, Backoff: 2 * time.Minute}
+
+	decision := policy.NextAttempt(outbox.Record{Attempts: 2}, errors.New("temporary"), now)
+
+	require.True(t, decision.Retry)
+	require.Equal(t, now.Add(2*time.Minute), decision.NextAttemptAt)
+	require.Equal(t, "temporary", decision.Reason)
+}
+
+// FixedBackoffPolicy must stop when the current claim already reached the
+// maximum total attempt count.
+func TestFixedBackoffPolicyStopsAtMaxAttempts(t *testing.T) {
+	policy := outbox.FixedBackoffPolicy{MaxAttempts: 3, Backoff: time.Minute}
+
+	decision := policy.NextAttempt(outbox.Record{Attempts: 3}, errors.New("still failing"), time.Now())
+
+	require.False(t, decision.Retry)
+	require.True(t, decision.NextAttemptAt.IsZero())
+	require.Equal(t, "still failing", decision.Reason)
+}

--- a/ddd/message/outbox/retry_test.go
+++ b/ddd/message/outbox/retry_test.go
@@ -43,3 +43,56 @@ func TestFixedBackoffPolicyStopsAtMaxAttempts(t *testing.T) {
 	require.True(t, decision.NextAttemptAt.IsZero())
 	require.Equal(t, "still failing", decision.Reason)
 }
+
+// FixedBackoffPolicy must treat zero max attempts as unlimited so callers can
+// opt out of terminal attempt counting without changing the backoff policy.
+func TestFixedBackoffPolicyWithZeroMaxAttemptsRetriesAsUnlimited(t *testing.T) {
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	policy := outbox.FixedBackoffPolicy{MaxAttempts: 0, Backoff: time.Minute}
+
+	decision := policy.NextAttempt(outbox.Record{Attempts: 100}, errors.New("temporary"), now)
+
+	require.True(t, decision.Retry)
+	require.Equal(t, now.Add(time.Minute), decision.NextAttemptAt)
+	require.Equal(t, "temporary", decision.Reason)
+}
+
+// FixedBackoffPolicy must treat negative max attempts as unlimited so invalid
+// non-positive limits do not make high-attempt records terminal.
+func TestFixedBackoffPolicyWithNegativeMaxAttemptsRetriesAsUnlimited(t *testing.T) {
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	policy := outbox.FixedBackoffPolicy{MaxAttempts: -1, Backoff: time.Minute}
+
+	decision := policy.NextAttempt(outbox.Record{Attempts: 100}, errors.New("temporary"), now)
+
+	require.True(t, decision.Retry)
+	require.Equal(t, now.Add(time.Minute), decision.NextAttemptAt)
+	require.Equal(t, "temporary", decision.Reason)
+}
+
+// FixedBackoffPolicy must allow zero backoff so callers can request immediate
+// retry scheduling at the relay clock time.
+func TestFixedBackoffPolicyWithZeroBackoffSchedulesAtNow(t *testing.T) {
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	policy := outbox.FixedBackoffPolicy{MaxAttempts: 3, Backoff: 0}
+
+	decision := policy.NextAttempt(outbox.Record{Attempts: 1}, errors.New("temporary"), now)
+
+	require.True(t, decision.Retry)
+	require.Equal(t, now, decision.NextAttemptAt)
+	require.Equal(t, "temporary", decision.Reason)
+}
+
+// FixedBackoffPolicy must preserve negative backoff durations so callers can
+// intentionally schedule retries before the relay clock time.
+func TestFixedBackoffPolicyWithNegativeBackoffSchedulesFromNow(t *testing.T) {
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	backoff := -time.Minute
+	policy := outbox.FixedBackoffPolicy{MaxAttempts: 3, Backoff: backoff}
+
+	decision := policy.NextAttempt(outbox.Record{Attempts: 1}, errors.New("temporary"), now)
+
+	require.True(t, decision.Retry)
+	require.Equal(t, now.Add(backoff), decision.NextAttemptAt)
+	require.Equal(t, "temporary", decision.Reason)
+}

--- a/ddd/message/outbox/store.go
+++ b/ddd/message/outbox/store.go
@@ -8,8 +8,8 @@ import (
 type Store interface {
 	Append(ctx context.Context, records ...Record) error
 	Claim(ctx context.Context, opts ClaimOptions) ([]Record, error)
-	MarkPublished(ctx context.Context, ids ...string) error
-	MarkFailed(ctx context.Context, id string, reason string, nextAttemptAt time.Time) error
+	MarkPublished(ctx context.Context, records ...Record) error
+	MarkFailed(ctx context.Context, record Record, reason string, nextAttemptAt time.Time) error
 }
 
 type ClaimOptions struct {
@@ -17,6 +17,12 @@ type ClaimOptions struct {
 	Now         time.Time
 	LockedUntil time.Time
 	ClaimedBy   string
+}
+
+// NormalizeClaimOptions fills default claim timestamps and validates the claim
+// window before a store attempts to lock records.
+func NormalizeClaimOptions(opts ClaimOptions, now func() time.Time) (ClaimOptions, error) {
+	return opts.normalize(now)
 }
 
 func (o ClaimOptions) normalize(now func() time.Time) (ClaimOptions, error) {

--- a/ddd/message/outbox/store.go
+++ b/ddd/message/outbox/store.go
@@ -1,0 +1,37 @@
+package outbox
+
+import (
+	"context"
+	"time"
+)
+
+type Store interface {
+	Append(ctx context.Context, records ...Record) error
+	Claim(ctx context.Context, opts ClaimOptions) ([]Record, error)
+	MarkPublished(ctx context.Context, ids ...string) error
+	MarkFailed(ctx context.Context, id string, reason string, nextAttemptAt time.Time) error
+}
+
+type ClaimOptions struct {
+	Limit       int
+	Now         time.Time
+	LockedUntil time.Time
+	ClaimedBy   string
+}
+
+func (o ClaimOptions) normalize(now func() time.Time) (ClaimOptions, error) {
+	if o.Limit <= 0 || o.ClaimedBy == "" {
+		return ClaimOptions{}, ErrInvalidClaimOptions
+	}
+	if o.Now.IsZero() {
+		if now == nil {
+			o.Now = time.Now()
+		} else {
+			o.Now = now()
+		}
+	}
+	if !o.LockedUntil.After(o.Now) {
+		return ClaimOptions{}, ErrInvalidClaimOptions
+	}
+	return o, nil
+}

--- a/ddd/message/outbox/store_test.go
+++ b/ddd/message/outbox/store_test.go
@@ -1,9 +1,10 @@
-package outbox
+package outbox_test
 
 import (
 	"testing"
 	"time"
 
+	"github.com/go-jimu/components/ddd/message/outbox"
 	"github.com/stretchr/testify/require"
 )
 
@@ -11,13 +12,13 @@ import (
 // to claim records.
 func TestClaimOptionsNormalize(t *testing.T) {
 	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
-	opts := ClaimOptions{
+	opts := outbox.ClaimOptions{
 		Limit:       10,
 		LockedUntil: now.Add(time.Minute),
 		ClaimedBy:   "worker-1",
 	}
 
-	normalized, err := opts.normalize(func() time.Time { return now })
+	normalized, err := outbox.NormalizeClaimOptions(opts, func() time.Time { return now })
 
 	require.NoError(t, err)
 	require.Equal(t, now, normalized.Now)
@@ -27,12 +28,12 @@ func TestClaimOptionsNormalize(t *testing.T) {
 func TestClaimOptionsNormalizeRejectsUnsafeOptions(t *testing.T) {
 	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
 
-	_, err := (ClaimOptions{Limit: 0, LockedUntil: now.Add(time.Minute), ClaimedBy: "worker-1"}).normalize(func() time.Time { return now })
-	require.ErrorIs(t, err, ErrInvalidClaimOptions)
+	_, err := outbox.NormalizeClaimOptions(outbox.ClaimOptions{Limit: 0, LockedUntil: now.Add(time.Minute), ClaimedBy: "worker-1"}, func() time.Time { return now })
+	require.ErrorIs(t, err, outbox.ErrInvalidClaimOptions)
 
-	_, err = (ClaimOptions{Limit: 1, LockedUntil: now.Add(time.Minute)}).normalize(func() time.Time { return now })
-	require.ErrorIs(t, err, ErrInvalidClaimOptions)
+	_, err = outbox.NormalizeClaimOptions(outbox.ClaimOptions{Limit: 1, LockedUntil: now.Add(time.Minute)}, func() time.Time { return now })
+	require.ErrorIs(t, err, outbox.ErrInvalidClaimOptions)
 
-	_, err = (ClaimOptions{Limit: 1, LockedUntil: now, ClaimedBy: "worker-1"}).normalize(func() time.Time { return now })
-	require.ErrorIs(t, err, ErrInvalidClaimOptions)
+	_, err = outbox.NormalizeClaimOptions(outbox.ClaimOptions{Limit: 1, LockedUntil: now, ClaimedBy: "worker-1"}, func() time.Time { return now })
+	require.ErrorIs(t, err, outbox.ErrInvalidClaimOptions)
 }

--- a/ddd/message/outbox/store_test.go
+++ b/ddd/message/outbox/store_test.go
@@ -1,0 +1,38 @@
+package outbox
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Claim options must produce a safe lock window before a relay asks the store
+// to claim records.
+func TestClaimOptionsNormalize(t *testing.T) {
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	opts := ClaimOptions{
+		Limit:       10,
+		LockedUntil: now.Add(time.Minute),
+		ClaimedBy:   "worker-1",
+	}
+
+	normalized, err := opts.normalize(func() time.Time { return now })
+
+	require.NoError(t, err)
+	require.Equal(t, now, normalized.Now)
+}
+
+// Invalid claim options must fail before a store attempts to lock records.
+func TestClaimOptionsNormalizeRejectsUnsafeOptions(t *testing.T) {
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+
+	_, err := (ClaimOptions{Limit: 0, LockedUntil: now.Add(time.Minute), ClaimedBy: "worker-1"}).normalize(func() time.Time { return now })
+	require.ErrorIs(t, err, ErrInvalidClaimOptions)
+
+	_, err = (ClaimOptions{Limit: 1, LockedUntil: now.Add(time.Minute)}).normalize(func() time.Time { return now })
+	require.ErrorIs(t, err, ErrInvalidClaimOptions)
+
+	_, err = (ClaimOptions{Limit: 1, LockedUntil: now, ClaimedBy: "worker-1"}).normalize(func() time.Time { return now })
+	require.ErrorIs(t, err, ErrInvalidClaimOptions)
+}

--- a/docs/project-knowledge/architecture.md
+++ b/docs/project-knowledge/architecture.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
-triggered_by_plan: 2026-05-10-integration-message.md
+triggered_by_plan: 2026-05-10-message-outbox.md
 ---
 
 # Architecture
@@ -30,6 +30,7 @@ compatible and adds DDD concept packages under `ddd/`.
 - `mediator/` — existing in-process event mediator with global default, event collection, subscription, dispatch, and graceful shutdown.
 - `ddd/event/` — DDD-oriented domain event collection, batch dispatch, and handler subscription. Key abstractions: `Event`, `Collection`, `Dispatcher`, `Subscriber`, `InMemoryDispatcher`, `Handler`.
 - `ddd/message/` — protobuf-first integration message DTO construction and deterministic handler routing for cross-context messaging. Key abstractions: `Message`, `Kind`, `Publisher`, `Subscriber`, `Handler`, `Router`.
+- `ddd/message/outbox/` — transactional outbox contracts and relay runtime for reliable integration message publishing. Key abstractions: `Record`, `Store`, `Recorder`, `Codec`, `RetryPolicy`, `Relay`.
 - `validation/` — notification and specification validation helpers.
 - `docs/superpowers/specs/` and `docs/superpowers/plans/` — design and implementation records for planned or recently completed work.
 
@@ -74,6 +75,20 @@ sequenceDiagram
     App->>Collection: Drain()
     App->>Dispatcher: DispatchAll(events batch)
     Dispatcher-->>App: dispatch error or nil
+```
+
+```mermaid
+sequenceDiagram
+    participant App as Application service
+    participant Recorder as ddd/message/outbox.Recorder
+    participant Store as outbox.Store
+    participant Relay as outbox.Relay
+    participant Publisher as message.Publisher
+    App->>Recorder: record integration message in business transaction
+    Recorder->>Store: append outbox record
+    Relay->>Store: claim due records
+    Relay->>Publisher: publish decoded message
+    Relay->>Store: mark published or failed
 ```
 
 ## Key Object FSMs

--- a/docs/project-knowledge/conventions.md
+++ b/docs/project-knowledge/conventions.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
-triggered_by_plan: 2026-05-10-integration-message.md
+triggered_by_plan: 2026-05-10-message-outbox.md
 ---
 
 # Conventions
@@ -24,7 +24,8 @@ triggered_by_plan: 2026-05-10-integration-message.md
 - `ddd/event` should document that it is for domain events inside one bounded context.
 - Domain event handlers in the planned module are follow-up reactions and do not report success back to the previous transaction.
 - `ddd/message` is for protobuf integration DTOs crossing bounded-context or service boundaries; it must remain separate from `ddd/event`.
-- Broker-specific envelope, acknowledgement, retry, DLQ, and outbox behavior should live outside the `ddd/message` core package.
+- `ddd/message/outbox` is the reliability subpackage for integration-message outbox contracts and relay runtime; keep it separate from `ddd/message` core DTO/routing APIs and from `ddd/event`.
+- Broker-specific envelope, acknowledgement, DLQ, concrete store, and concrete broker adapter behavior should live outside both `ddd/message` and `ddd/message/outbox`.
 
 ## Git And CI
 

--- a/docs/project-knowledge/features.md
+++ b/docs/project-knowledge/features.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
-triggered_by_plan: 2026-05-10-integration-message.md
+triggered_by_plan: 2026-05-10-message-outbox.md
 ---
 
 # Features
@@ -12,84 +12,91 @@ triggered_by_plan: 2026-05-10-integration-message.md
 
 #### Config loading and watching
 
-- Enables: consumers combine sources, load values, resolve references, and observe updates.
-- Actors / Entry Points: library consumers call `config.New`, `Load`, `Value`, `Watch`, and `Close`.
-- Capability Boundary: package-level configuration component; not an application configuration service.
-- References: `config/`
+**Enables** — Consumers combine sources, load values, resolve references, and observe updates.
+**Actors / Entry Points** — Library consumers call `config.New`, `Load`, `Value`, `Watch`, and `Close`.
+**Capability Boundary** — Package-level configuration component; not an application configuration service.
+**References** — `config/`
 
 ### Encoding
 
 #### Codec registry
 
-- Enables: consumers register and retrieve codecs by stable names.
-- Actors / Entry Points: codec packages register themselves; consumers call `encoding.GetCodec`.
-- Capability Boundary: registry and codec abstraction only; transport usage lives in consumers.
-- References: `encoding/`
+**Enables** — Consumers register and retrieve codecs by stable names.
+**Actors / Entry Points** — Codec packages register themselves; consumers call `encoding.GetCodec`.
+**Capability Boundary** — Registry and codec abstraction only; transport usage lives in consumers.
+**References** — `encoding/`
 
 ### State Machines
 
 #### FSM primitives
 
-- Enables: consumers define states, actions, conditions, and transitions.
-- Actors / Entry Points: consumers use `fsm.StateMachine` and related primitives.
-- Capability Boundary: generic state-machine utility; no business aggregate model is included.
-- References: `fsm/`
+**Enables** — Consumers define states, actions, conditions, and transitions.
+**Actors / Entry Points** — Consumers use `fsm.StateMachine` and related primitives.
+**Capability Boundary** — Generic state-machine utility; no business aggregate model is included.
+**References** — `fsm/`
 
 ### Logging
 
 #### Logger helpers
 
-- Enables: consumers attach and derive loggers and attributes with `log/slog`.
-- Actors / Entry Points: library consumers import `logger` and `sloghelper`.
-- Capability Boundary: logging utilities only; no centralized logging backend.
-- References: `logger/`, `sloghelper/`
+**Enables** — Consumers attach and derive loggers and attributes with `log/slog`.
+**Actors / Entry Points** — Library consumers import `logger` and `sloghelper`.
+**Capability Boundary** — Logging utilities only; no centralized logging backend.
+**References** — `logger/`, `sloghelper/`
 
 ### Mediator
 
 #### Existing in-process mediator
 
-- Enables: existing consumers subscribe handlers and dispatch events with graceful shutdown behavior.
-- Actors / Entry Points: consumers use `mediator.NewInMemMediator`, `Dispatch`, `Subscribe`, and `EventCollection`.
-- Capability Boundary: legacy compatibility package; new domain event code should use `ddd/event`.
-- References: `mediator/`, `docs/mediator-migration.md`
+**Enables** — Existing consumers subscribe handlers and dispatch events with graceful shutdown behavior.
+**Actors / Entry Points** — Consumers use `mediator.NewInMemMediator`, `Dispatch`, `Subscribe`, and `EventCollection`.
+**Capability Boundary** — Legacy compatibility package; new domain event code should use `ddd/event`.
+**References** — `mediator/`, `docs/mediator-migration.md`
 
 ### DDD Event
 
 #### Domain event collection and dispatch
 
-- Enables: services collect and submit domain event batches after persistence.
-- Actors / Entry Points: domain aggregates use `ddd/event.Collection`; application services use `ddd/event.Dispatcher`, `Subscriber`, or `InMemoryDispatcher`.
-- Capability Boundary: domain events inside one bounded context only; dispatch errors mean admission or delivery failure, not handler business failure.
-- References: `ddd/event/`, `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
+**Enables** — Services collect and submit domain event batches after persistence.
+**Actors / Entry Points** — Domain aggregates use `ddd/event.Collection`; application services use `ddd/event.Dispatcher`, `Subscriber`, or `InMemoryDispatcher`.
+**Capability Boundary** — Domain events inside one bounded context only; dispatch errors mean admission or delivery failure, not handler business failure.
+**References** — `ddd/event/`, `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 
 #### Dispatcher runtime diagnostics
 
-- Enables: dispatcher owners trace runtime dispatch health and shutdown interruptions.
-- Actors / Entry Points: application services configure `ddd/event.Dispatcher` options and consume logs or runtime hooks.
-- Capability Boundary: diagnostics for domain event dispatch only; forced shutdown pending events are best-effort offline compensation clues, not a durable event audit log.
-- References: `ddd/event/`, `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
+**Enables** — Dispatcher owners trace runtime dispatch health and shutdown interruptions.
+**Actors / Entry Points** — Application services configure `ddd/event.Dispatcher` options and consume logs or runtime hooks.
+**Capability Boundary** — Diagnostics for domain event dispatch only; forced shutdown pending events are best-effort offline compensation clues, not a durable event audit log.
+**References** — `ddd/event/`, `docs/superpowers/specs/2026-05-10-ddd-event-design.md`
 
 ### DDD Message
 
 #### Protobuf integration message DTOs
 
-- Enables: consumers create transport-neutral integration messages for cross bounded-context or service communication.
-- Actors / Entry Points: application or infrastructure mapping code calls `message.New`, `KindOf`, and message option helpers.
-- Capability Boundary: direct non-transactional integration messaging only; outbox, retry, DLQ, and concrete broker adapters remain outside the core package.
-- References: `ddd/message/`, `docs/superpowers/specs/2026-05-10-integration-message-design.md`
+**Enables** — Consumers create transport-neutral integration messages for cross bounded-context or service communication.
+**Actors / Entry Points** — Application or infrastructure mapping code calls `message.New`, `KindOf`, and message option helpers.
+**Capability Boundary** — Direct non-transactional integration messaging only; concrete broker adapters and durable reliability live outside the core package.
+**References** — `ddd/message/`, `docs/superpowers/specs/2026-05-10-integration-message-design.md`
 
 #### Integration message routing
 
-- Enables: consumers route received integration messages to handlers by message kind.
-- Actors / Entry Points: consumers register `message.Handler` values through `message.Router` or a `Subscriber`.
-- Capability Boundary: router handles in-process handler matching and first-error stop; acknowledgement, offset commit, and broker envelope mapping belong to adapters.
-- References: `ddd/message/`, `docs/superpowers/specs/2026-05-10-integration-message-design.md`
+**Enables** — Consumers route received integration messages to handlers by message kind.
+**Actors / Entry Points** — Consumers register `message.Handler` values through `message.Router` or a `Subscriber`.
+**Capability Boundary** — Router handles in-process handler matching and first-error stop; acknowledgement, offset commit, and broker envelope mapping belong to adapters.
+**References** — `ddd/message/`, `docs/superpowers/specs/2026-05-10-integration-message-design.md`
+
+#### Transactional outbox primitives
+
+**Enables** — Consumers record integration messages with business transactions and relay them later with at-least-once publishing.
+**Actors / Entry Points** — Application services use `outbox.Recorder`; infrastructure/runtime workers use `outbox.Relay`; concrete stores implement `outbox.Store`.
+**Capability Boundary** — Provides record, codec, store, recorder, retry, and relay contracts only; no SQL store, migration, broker adapter, DLQ, or domain event outbox.
+**References** — `ddd/message/outbox/`, `docs/superpowers/specs/2026-05-10-message-outbox-design.md`, `docs/superpowers/plans/2026-05-10-message-outbox.md`
 
 ### Validation
 
 #### Notification and specification helpers
 
-- Enables: consumers collect validation notifications and apply specification-style checks.
-- Actors / Entry Points: consumers import `validation`.
-- Capability Boundary: generic validation helpers; no application validation framework.
-- References: `validation/`
+**Enables** — Consumers collect validation notifications and apply specification-style checks.
+**Actors / Entry Points** — Consumers import `validation`.
+**Capability Boundary** — Generic validation helpers; no application validation framework.
+**References** — `validation/`

--- a/docs/project-knowledge/glossary.md
+++ b/docs/project-knowledge/glossary.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
-triggered_by_plan: 2026-05-10-integration-message.md
+triggered_by_plan: 2026-05-10-message-outbox.md
 ---
 
 # Glossary
@@ -30,4 +30,12 @@ triggered_by_plan: 2026-05-10-integration-message.md
 
 **Router** — In-process integration message handler router keyed by message kind. → `ddd/message/`
 
-**Outbox** — Future reliability mechanism for integration messages, not a domain event dispatcher. → `docs/superpowers/specs/2026-05-10-integration-message-design.md`
+**Outbox** — Integration-message reliability mechanism that stores records for relay after commit. → `ddd/message/outbox/`
+
+**Outbox Record** — Durable lifecycle record for one integration message. → `ddd/message/outbox/`
+
+**Recorder** — Transaction-time component that encodes messages and appends outbox records without publishing. → `ddd/message/outbox/`
+
+**Relay** — Runtime worker that claims outbox records, publishes messages, and marks lifecycle state. → `ddd/message/outbox/`
+
+**Retry Policy** — Rule deciding whether a failed outbox record gets another attempt and when. → `ddd/message/outbox/`

--- a/docs/project-knowledge/index.md
+++ b/docs/project-knowledge/index.md
@@ -1,15 +1,26 @@
 ---
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
-triggered_by_plan: 2026-05-10-integration-message.md
-covers_branch: release/message@5d7b730
+triggered_by_plan: 2026-05-10-message-outbox.md
+covers_branch: release/message@c57db69
 ---
 
 # Project Knowledge Index
 
-- `architecture.md` — top-level Go component layout including `ddd/event` for domain events and `ddd/message` for integration DTO messages.
-- `features.md` — current capabilities including legacy `mediator`, `ddd/event`, `ddd/message` construction/routing, and diagnostics.
-- `tech-stack.md` — Go 1.24 module, CI matrix 1.23/1.24/1.25, core dependencies and Make targets.
-- `conventions.md` — package style, DDD event/message boundaries, tests with `go test -race -covermode=atomic`, CI/benchmark workflow.
-- `decisions.md` — design decision summary for preserving `mediator`, adding `ddd/event`, and modeling `ddd/message` separately.
-- `glossary.md` — project terms including legacy mediator, domain event, integration message, message kind/key, router, and outbox.
+- [architecture.md](architecture.md) — System boundaries, package layering, and core scenario flows.
+  Key points: component library with independent Go packages; DDD event, message, and message outbox packages live under `ddd/`.
+
+- [tech-stack.md](tech-stack.md) — Languages, frameworks, and key dependencies.
+  Key points: Go 1.24 module; protobuf support comes from `google.golang.org/protobuf`.
+
+- [features.md](features.md) — Implemented package capabilities and boundaries.
+  Key points: implemented config, encoding, fsm, logging, mediator, DDD event, DDD message, message outbox, and validation capabilities.
+
+- [conventions.md](conventions.md) — Coding, testing, event, message, and CI rules.
+  Key points: keep `mediator`, `ddd/event`, `ddd/message`, and `ddd/message/outbox` responsibilities separate; CI expects `make test`.
+
+- [decisions.md](decisions.md) — Architecture decision summaries and known issues.
+  Key points: DDD concepts live under `ddd/`; integration messages are protobuf DTOs separate from domain events.
+
+- [glossary.md](glossary.md) — Project terminology and package ownership.
+  Key points: defines domain event, integration message, message kind/key, publisher/subscriber/router, and outbox lifecycle terms.

--- a/docs/superpowers/plans/2026-05-10-message-outbox.md
+++ b/docs/superpowers/plans/2026-05-10-message-outbox.md
@@ -1,0 +1,1320 @@
+# Message Outbox Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `ddd/message/outbox`, an additive outbox abstraction for reliable at-least-once publishing of integration messages.
+
+**Architecture:** The package sits under `ddd/message/outbox` and depends on the existing protobuf-first `ddd/message` package. `Recorder` records messages inside the caller's transaction through `Store.Append`; `Relay` claims stored records, decodes them, publishes through `message.Publisher`, and marks lifecycle state. Store locking, retry, and relay loops are infrastructure/runtime concerns, not domain-event behavior.
+
+**Tech Stack:** Go 1.24, `google.golang.org/protobuf/proto`, existing `github.com/go-jimu/components/ddd/message`, existing `encoding/testdata` protobuf fixtures, `testify/require`.
+
+---
+
+## Scope Check
+
+The approved spec covers one bounded implementation unit: `ddd/message/outbox`.
+It intentionally excludes SQL store implementations, migrations, broker
+adapters, dead-letter queues, exponential backoff, and changes to `ddd/event` or
+`ddd/message`.
+
+## Architecture Gate
+
+- Gate level: Level 3, new reliability subpackage with explicit durable
+  lifecycle states.
+- Bounded context / business capability: shared component library capability for
+  transactional reliability of integration messages.
+- Stable language / data authority: `message.Message` is the integration DTO;
+  `outbox.Record` is the durable lifecycle record; `Store` is authoritative for
+  lifecycle state.
+- Affected aggregate, policy, or service: no business aggregate; affects
+  recording, encoding, claiming, relay publishing, and retry policy.
+- Invariants and rules: record in the same business transaction; recorder never
+  publishes; claim atomically locks; relay is at-least-once; consumers dedupe by
+  `message.ID`.
+- Technical capability classification: application transaction-boundary support
+  plus infrastructure/runtime lifecycle management.
+- Layer ownership: Application maps domain facts to `message.Message` and calls
+  `Recorder`; Infrastructure owns outbox persistence, locking, relay execution,
+  and broker publisher implementations.
+- Proceed / Stop: proceed with implementation through this plan.
+
+## File Structure
+
+- Create `ddd/message/outbox/doc.go`: package documentation and usage contract.
+- Create `ddd/message/outbox/errors.go`: sentinel errors used across the
+  package.
+- Create `ddd/message/outbox/record.go`: `Status`, `Record`, cloning, and
+  record ID generation.
+- Create `ddd/message/outbox/store.go`: `Store`, `ClaimOptions`, and option
+  normalization used by relay and store implementations.
+- Create `ddd/message/outbox/codec.go`: `Codec` and protobuf-backed
+  `ProtoCodec`.
+- Create `ddd/message/outbox/recorder.go`: `Recorder` and default
+  `StoreRecorder`.
+- Create `ddd/message/outbox/retry.go`: retry policy interface,
+  `NoRetryPolicy`, and `FixedBackoffPolicy`.
+- Create `ddd/message/outbox/relay.go`: `Relay`, `RunOnce`, and `Run`.
+- Create focused `_test.go` files beside each production file.
+
+## Test List
+
+Intent source: approved spec at
+`docs/superpowers/specs/2026-05-10-message-outbox-design.md`.
+
+- [ ] unit: `Record.Clone` copies payload and headers -> mutations of the copy
+  do not alter the source record.
+- [ ] unit: `ProtoCodec` round-trips a protobuf message -> decoded
+  `message.Message` preserves ID, kind, key, occurred time, headers, and payload.
+- [ ] unit: `ProtoCodec.Register` rejects empty kind and nil factory -> invalid
+  registries cannot decode records ambiguously.
+- [ ] unit: `ProtoCodec.Decode` rejects unknown kinds -> missing published
+  language registration is visible before publishing.
+- [ ] unit: `StoreRecorder.Record` encodes all messages and appends once ->
+  transaction-time recording has no direct publish side effect.
+- [ ] unit: `StoreRecorder.Record` stops on encode failure -> invalid messages
+  are not partially appended.
+- [ ] unit: `ClaimOptions` normalization fills zero `Now` and rejects invalid
+  limit, worker, or lock window -> relay workers do not claim with unsafe locks.
+- [ ] unit: `NoRetryPolicy` returns terminal failure -> default behavior does
+  not create retry loops.
+- [ ] unit: `FixedBackoffPolicy` retries below max attempts and stops at max ->
+  attempt counting matches `Store.Claim` semantics.
+- [ ] unit: `Relay.RunOnce` publishes claimed records and marks them published
+  -> successful records leave processing state.
+- [ ] unit: `Relay.RunOnce` marks decode and publish failures through retry
+  policy -> failed delivery is persisted with the right next attempt.
+- [ ] unit: `Relay.RunOnce` reports mark failures -> at-least-once duplicate
+  risk remains visible to operators.
+- [ ] unit: `Relay.Run` rejects non-positive intervals and stops on context
+  cancellation -> loop lifecycle is explicit.
+
+## Task 1: Record, Errors, And Package Docs
+
+**Files:**
+- Create: `ddd/message/outbox/doc.go`
+- Create: `ddd/message/outbox/errors.go`
+- Create: `ddd/message/outbox/record.go`
+- Test: `ddd/message/outbox/record_test.go`
+
+- [ ] **Step 1: Write the failing record clone test**
+
+Create `ddd/message/outbox/record_test.go`:
+
+```go
+package outbox_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message"
+	"github.com/go-jimu/components/ddd/message/outbox"
+	"github.com/stretchr/testify/require"
+)
+
+// Clone must copy mutable payload and header data so store implementations can
+// hand records to callers without exposing shared mutation.
+func TestRecordCloneCopiesMutableFields(t *testing.T) {
+	original := outbox.Record{
+		ID:         "record-1",
+		MessageID:  "message-1",
+		Kind:       message.Kind("test.test_model"),
+		Key:        "order-1",
+		OccurredAt: time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC),
+		Payload:    []byte{1, 2, 3},
+		Headers:    map[string]string{"tenant": "tenant-a"},
+		Status:     outbox.StatusPending,
+	}
+
+	cloned := original.Clone()
+	cloned.Payload[0] = 9
+	cloned.Headers["tenant"] = "tenant-b"
+
+	require.Equal(t, []byte{1, 2, 3}, original.Payload)
+	require.Equal(t, map[string]string{"tenant": "tenant-a"}, original.Headers)
+	require.Equal(t, "record-1", cloned.ID)
+}
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `go test ./ddd/message/outbox -run TestRecordCloneCopiesMutableFields -count=1`
+
+Expected: FAIL because `ddd/message/outbox` does not exist.
+
+- [ ] **Step 3: Add docs, errors, and record implementation**
+
+Create `ddd/message/outbox/doc.go`:
+
+```go
+// Package outbox provides transaction-time recording and relay primitives for
+// reliable integration message publishing.
+//
+// Record messages through Recorder inside the same transaction as the business
+// write. Publish them through Relay after commit. Delivery is at-least-once, so
+// consumers must deduplicate by message.Message.ID.
+package outbox
+```
+
+Create `ddd/message/outbox/errors.go`:
+
+```go
+package outbox
+
+import "errors"
+
+var (
+	ErrNilStore            = errors.New("outbox: nil store")
+	ErrNilCodec            = errors.New("outbox: nil codec")
+	ErrNilPublisher        = errors.New("outbox: nil publisher")
+	ErrInvalidClaimOptions = errors.New("outbox: invalid claim options")
+	ErrInvalidRunOptions   = errors.New("outbox: invalid run options")
+	ErrUnknownKind         = errors.New("outbox: unknown message kind")
+	ErrNilFactory          = errors.New("outbox: nil protobuf factory")
+)
+```
+
+Create `ddd/message/outbox/record.go`:
+
+```go
+package outbox
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message"
+)
+
+type Status string
+
+const (
+	StatusPending    Status = "pending"
+	StatusProcessing Status = "processing"
+	StatusPublished  Status = "published"
+	StatusFailed     Status = "failed"
+)
+
+type Record struct {
+	ID         string
+	MessageID  string
+	Kind       message.Kind
+	Key        string
+	OccurredAt time.Time
+	Payload    []byte
+	Headers    map[string]string
+
+	Status        Status
+	Attempts      int
+	NextAttemptAt time.Time
+	LockedUntil   time.Time
+	ClaimedBy     string
+	LastError     string
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+func (r Record) Clone() Record {
+	r.Payload = cloneBytes(r.Payload)
+	r.Headers = cloneHeaders(r.Headers)
+	return r
+}
+
+func cloneBytes(src []byte) []byte {
+	if len(src) == 0 {
+		return nil
+	}
+	dst := make([]byte, len(src))
+	copy(dst, src)
+	return dst
+}
+
+func cloneHeaders(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(headers))
+	for key, value := range headers {
+		copied[key] = value
+	}
+	return copied
+}
+
+func generateID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
+}
+```
+
+- [ ] **Step 4: Run the record test and verify it passes**
+
+Run: `go test ./ddd/message/outbox -run TestRecordCloneCopiesMutableFields -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ddd/message/outbox
+git commit -m "feat: add outbox record"
+```
+
+## Task 2: Proto Codec
+
+**Files:**
+- Create: `ddd/message/outbox/codec.go`
+- Test: `ddd/message/outbox/codec_test.go`
+
+- [ ] **Step 1: Write failing codec tests**
+
+Create `ddd/message/outbox/codec_test.go`:
+
+```go
+package outbox_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message"
+	"github.com/go-jimu/components/ddd/message/outbox"
+	testdata "github.com/go-jimu/components/encoding/testdata"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// ProtoCodec must round-trip the published protobuf contract and all message
+// metadata needed for idempotency, routing, and tracing.
+func TestProtoCodecRoundTrip(t *testing.T) {
+	codec := outbox.NewProtoCodec()
+	require.NoError(t, codec.Register("test.test_model", func() proto.Message {
+		return &testdata.TestModel{}
+	}))
+	occurredAt := time.Date(2026, 5, 10, 12, 30, 0, 0, time.UTC)
+	msg, err := message.New(
+		"test.test_model",
+		&testdata.TestModel{Id: 7, Name: "paid"},
+		message.WithID("message-1"),
+		message.WithKey("order-7"),
+		message.WithOccurredAt(occurredAt),
+		message.WithHeader("trace_id", "trace-1"),
+	)
+	require.NoError(t, err)
+
+	record, err := codec.Encode(msg)
+	require.NoError(t, err)
+	decoded, err := codec.Decode(record)
+	require.NoError(t, err)
+
+	require.NotEmpty(t, record.ID)
+	require.Equal(t, "message-1", record.MessageID)
+	require.Equal(t, outbox.StatusPending, record.Status)
+	require.Equal(t, "message-1", decoded.ID())
+	require.Equal(t, message.Kind("test.test_model"), decoded.Kind())
+	require.Equal(t, "order-7", decoded.Key())
+	require.Equal(t, occurredAt, decoded.OccurredAt())
+	require.Equal(t, map[string]string{"trace_id": "trace-1"}, decoded.Headers())
+	require.Equal(t, &testdata.TestModel{Id: 7, Name: "paid"}, decoded.Payload())
+}
+
+// Invalid registry entries must fail before decode time so missing published
+// language registrations are caught near application startup.
+func TestProtoCodecRejectsInvalidRegistration(t *testing.T) {
+	codec := outbox.NewProtoCodec()
+
+	require.True(t, errors.Is(codec.Register("", func() proto.Message {
+		return &testdata.TestModel{}
+	}), message.ErrEmptyKind))
+	require.True(t, errors.Is(codec.Register("test.test_model", nil), outbox.ErrNilFactory))
+}
+
+// Unknown kinds must be rejected because the relay cannot reconstruct the
+// protobuf payload without a registered factory.
+func TestProtoCodecRejectsUnknownKind(t *testing.T) {
+	codec := outbox.NewProtoCodec()
+
+	_, err := codec.Decode(outbox.Record{
+		ID:        "record-1",
+		MessageID: "message-1",
+		Kind:      "missing.kind",
+		Payload:   []byte{1, 2, 3},
+	})
+
+	require.True(t, errors.Is(err, outbox.ErrUnknownKind))
+}
+
+// Encoding an absent protobuf payload must fail instead of producing an
+// unpublishable outbox record.
+func TestProtoCodecRejectsNilPayload(t *testing.T) {
+	codec := outbox.NewProtoCodec()
+
+	_, err := codec.Encode(message.Message{})
+
+	require.True(t, errors.Is(err, message.ErrNilPayload))
+}
+```
+
+- [ ] **Step 2: Run codec tests and verify they fail**
+
+Run: `go test ./ddd/message/outbox -run 'TestProtoCodec' -count=1`
+
+Expected: FAIL because `ProtoCodec` is not defined.
+
+- [ ] **Step 3: Implement `Codec` and `ProtoCodec`**
+
+Create `ddd/message/outbox/codec.go`:
+
+```go
+package outbox
+
+import (
+	"sync"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message"
+	"google.golang.org/protobuf/proto"
+)
+
+type Codec interface {
+	Encode(message.Message) (Record, error)
+	Decode(Record) (message.Message, error)
+}
+
+type ProtoCodec struct {
+	mu        sync.RWMutex
+	factories map[message.Kind]func() proto.Message
+}
+
+func NewProtoCodec() *ProtoCodec {
+	return &ProtoCodec{factories: make(map[message.Kind]func() proto.Message)}
+}
+
+func (c *ProtoCodec) Register(kind message.Kind, factory func() proto.Message) error {
+	if kind == "" {
+		return message.ErrEmptyKind
+	}
+	if factory == nil {
+		return ErrNilFactory
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.factories[kind] = factory
+	return nil
+}
+
+func (c *ProtoCodec) Encode(msg message.Message) (Record, error) {
+	if msg.Payload() == nil {
+		return Record{}, message.ErrNilPayload
+	}
+	if msg.Kind() == "" {
+		return Record{}, message.ErrEmptyKind
+	}
+	payload, err := proto.Marshal(msg.Payload())
+	if err != nil {
+		return Record{}, err
+	}
+	id, err := generateID()
+	if err != nil {
+		return Record{}, err
+	}
+	now := time.Now()
+	return Record{
+		ID:         id,
+		MessageID:  msg.ID(),
+		Kind:       msg.Kind(),
+		Key:        msg.Key(),
+		OccurredAt: msg.OccurredAt(),
+		Payload:    payload,
+		Headers:    msg.Headers(),
+		Status:     StatusPending,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}, nil
+}
+
+func (c *ProtoCodec) Decode(record Record) (message.Message, error) {
+	c.mu.RLock()
+	factory := c.factories[record.Kind]
+	c.mu.RUnlock()
+	if factory == nil {
+		return message.Message{}, ErrUnknownKind
+	}
+	payload := factory()
+	if payload == nil {
+		return message.Message{}, ErrNilFactory
+	}
+	if err := proto.Unmarshal(record.Payload, payload); err != nil {
+		return message.Message{}, err
+	}
+	return message.New(
+		record.Kind,
+		payload,
+		message.WithID(record.MessageID),
+		message.WithKey(record.Key),
+		message.WithOccurredAt(record.OccurredAt),
+		message.WithHeaders(record.Headers),
+	)
+}
+```
+
+- [ ] **Step 4: Run codec tests and verify they pass**
+
+Run: `go test ./ddd/message/outbox -run 'TestProtoCodec' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ddd/message/outbox
+git commit -m "feat: add outbox protobuf codec"
+```
+
+## Task 3: Store Contract And Recorder
+
+**Files:**
+- Create: `ddd/message/outbox/store.go`
+- Create: `ddd/message/outbox/recorder.go`
+- Test: `ddd/message/outbox/recorder_test.go`
+- Test: `ddd/message/outbox/store_test.go`
+
+- [ ] **Step 1: Write failing recorder and claim option tests**
+
+Create `ddd/message/outbox/recorder_test.go`:
+
+```go
+package outbox_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message"
+	"github.com/go-jimu/components/ddd/message/outbox"
+	testdata "github.com/go-jimu/components/encoding/testdata"
+	"github.com/stretchr/testify/require"
+)
+
+// Recorder must append encoded records through Store without publishing
+// anything, preserving transaction-time responsibility at the store boundary.
+func TestRecorderRecordsMessagesThroughStore(t *testing.T) {
+	codec := outbox.NewProtoCodec()
+	msg, err := message.New("test.test_model", &testdata.TestModel{}, message.WithID("message-1"))
+	require.NoError(t, err)
+	store := &fakeStore{}
+	recorder, err := outbox.NewRecorder(store, codec)
+	require.NoError(t, err)
+
+	require.NoError(t, recorder.Record(context.Background(), msg))
+
+	require.Len(t, store.appended, 1)
+	require.Equal(t, "message-1", store.appended[0].MessageID)
+	require.Equal(t, outbox.StatusPending, store.appended[0].Status)
+}
+
+// Recorder construction must reject missing collaborators so transaction-time
+// recording cannot silently drop messages.
+func TestNewRecorderRejectsMissingCollaborators(t *testing.T) {
+	_, err := outbox.NewRecorder(nil, outbox.NewProtoCodec())
+	require.True(t, errors.Is(err, outbox.ErrNilStore))
+
+	_, err = outbox.NewRecorder(&fakeStore{}, nil)
+	require.True(t, errors.Is(err, outbox.ErrNilCodec))
+}
+
+type fakeStore struct {
+	appended []outbox.Record
+}
+
+func (s *fakeStore) Append(_ context.Context, records ...outbox.Record) error {
+	s.appended = append(s.appended, records...)
+	return nil
+}
+
+func (s *fakeStore) Claim(context.Context, outbox.ClaimOptions) ([]outbox.Record, error) {
+	return nil, nil
+}
+
+func (s *fakeStore) MarkPublished(context.Context, ...string) error {
+	return nil
+}
+
+func (s *fakeStore) MarkFailed(context.Context, string, string, time.Time) error {
+	return nil
+}
+```
+
+Create `ddd/message/outbox/store_test.go`:
+
+```go
+package outbox
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Claim options must produce a safe lock window before a relay asks the store
+// to claim records.
+func TestClaimOptionsNormalize(t *testing.T) {
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	opts := ClaimOptions{
+		Limit:       10,
+		LockedUntil: now.Add(time.Minute),
+		ClaimedBy:   "worker-1",
+	}
+
+	normalized, err := opts.normalize(func() time.Time { return now })
+
+	require.NoError(t, err)
+	require.Equal(t, now, normalized.Now)
+}
+
+// Invalid claim options must fail before a store attempts to lock records.
+func TestClaimOptionsNormalizeRejectsUnsafeOptions(t *testing.T) {
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+
+	_, err := (ClaimOptions{Limit: 0, LockedUntil: now.Add(time.Minute), ClaimedBy: "worker-1"}).normalize(func() time.Time { return now })
+	require.ErrorIs(t, err, ErrInvalidClaimOptions)
+
+	_, err = (ClaimOptions{Limit: 1, LockedUntil: now.Add(time.Minute)}).normalize(func() time.Time { return now })
+	require.ErrorIs(t, err, ErrInvalidClaimOptions)
+
+	_, err = (ClaimOptions{Limit: 1, LockedUntil: now, ClaimedBy: "worker-1"}).normalize(func() time.Time { return now })
+	require.ErrorIs(t, err, ErrInvalidClaimOptions)
+}
+```
+
+- [ ] **Step 2: Run recorder tests and verify they fail**
+
+Run: `go test ./ddd/message/outbox -run 'TestRecorder|TestNewRecorder|TestClaimOptions' -count=1`
+
+Expected: FAIL because `Store`, `Recorder`, and `ClaimOptions` are not defined.
+
+- [ ] **Step 3: Implement store contract and recorder**
+
+Create `ddd/message/outbox/store.go`:
+
+```go
+package outbox
+
+import (
+	"context"
+	"time"
+)
+
+type Store interface {
+	Append(ctx context.Context, records ...Record) error
+	Claim(ctx context.Context, opts ClaimOptions) ([]Record, error)
+	MarkPublished(ctx context.Context, ids ...string) error
+	MarkFailed(ctx context.Context, id string, reason string, nextAttemptAt time.Time) error
+}
+
+type ClaimOptions struct {
+	Limit       int
+	Now         time.Time
+	LockedUntil time.Time
+	ClaimedBy   string
+}
+
+func (o ClaimOptions) normalize(now func() time.Time) (ClaimOptions, error) {
+	if o.Limit <= 0 || o.ClaimedBy == "" {
+		return ClaimOptions{}, ErrInvalidClaimOptions
+	}
+	if o.Now.IsZero() {
+		if now == nil {
+			o.Now = time.Now()
+		} else {
+			o.Now = now()
+		}
+	}
+	if !o.LockedUntil.After(o.Now) {
+		return ClaimOptions{}, ErrInvalidClaimOptions
+	}
+	return o, nil
+}
+```
+
+Create `ddd/message/outbox/recorder.go`:
+
+```go
+package outbox
+
+import (
+	"context"
+
+	"github.com/go-jimu/components/ddd/message"
+)
+
+type Recorder interface {
+	Record(ctx context.Context, messages ...message.Message) error
+}
+
+type RecorderOption func(*recorderConfig)
+
+type recorderConfig struct{}
+
+type StoreRecorder struct {
+	store Store
+	codec Codec
+}
+
+func NewRecorder(store Store, codec Codec, opts ...RecorderOption) (*StoreRecorder, error) {
+	if store == nil {
+		return nil, ErrNilStore
+	}
+	if codec == nil {
+		return nil, ErrNilCodec
+	}
+	cfg := recorderConfig{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return &StoreRecorder{store: store, codec: codec}, nil
+}
+
+func (r *StoreRecorder) Record(ctx context.Context, messages ...message.Message) error {
+	if len(messages) == 0 {
+		return nil
+	}
+	records := make([]Record, 0, len(messages))
+	for _, msg := range messages {
+		record, err := r.codec.Encode(msg)
+		if err != nil {
+			return err
+		}
+		records = append(records, record)
+	}
+	return r.store.Append(ctx, records...)
+}
+```
+
+- [ ] **Step 4: Run recorder tests and verify they pass**
+
+Run: `go test ./ddd/message/outbox -run 'TestRecorder|TestNewRecorder|TestClaimOptions' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ddd/message/outbox
+git commit -m "feat: add outbox recorder"
+```
+
+## Task 4: Retry Policies
+
+**Files:**
+- Create: `ddd/message/outbox/retry.go`
+- Test: `ddd/message/outbox/retry_test.go`
+
+- [ ] **Step 1: Write failing retry tests**
+
+Create `ddd/message/outbox/retry_test.go`:
+
+```go
+package outbox_test
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message/outbox"
+	"github.com/stretchr/testify/require"
+)
+
+// NoRetryPolicy must make failures terminal by default so relays do not create
+// unbounded retry loops unless callers choose a retry policy.
+func TestNoRetryPolicyReturnsTerminalDecision(t *testing.T) {
+	decision := outbox.NoRetryPolicy{}.NextAttempt(outbox.Record{}, errors.New("publish failed"), time.Now())
+
+	require.False(t, decision.Retry)
+	require.True(t, decision.NextAttemptAt.IsZero())
+	require.Equal(t, "publish failed", decision.Reason)
+}
+
+// FixedBackoffPolicy must retry below the max attempt count using the configured
+// delay from the relay clock.
+func TestFixedBackoffPolicyRetriesBelowMaxAttempts(t *testing.T) {
+	now := time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+	policy := outbox.FixedBackoffPolicy{MaxAttempts: 3, Backoff: 2 * time.Minute}
+
+	decision := policy.NextAttempt(outbox.Record{Attempts: 2}, errors.New("temporary"), now)
+
+	require.True(t, decision.Retry)
+	require.Equal(t, now.Add(2*time.Minute), decision.NextAttemptAt)
+	require.Equal(t, "temporary", decision.Reason)
+}
+
+// FixedBackoffPolicy must stop when the current claim already reached the
+// maximum total attempt count.
+func TestFixedBackoffPolicyStopsAtMaxAttempts(t *testing.T) {
+	policy := outbox.FixedBackoffPolicy{MaxAttempts: 3, Backoff: time.Minute}
+
+	decision := policy.NextAttempt(outbox.Record{Attempts: 3}, errors.New("still failing"), time.Now())
+
+	require.False(t, decision.Retry)
+	require.True(t, decision.NextAttemptAt.IsZero())
+	require.Equal(t, "still failing", decision.Reason)
+}
+```
+
+- [ ] **Step 2: Run retry tests and verify they fail**
+
+Run: `go test ./ddd/message/outbox -run 'Test.*Policy' -count=1`
+
+Expected: FAIL because retry policies are not defined.
+
+- [ ] **Step 3: Implement retry policies**
+
+Create `ddd/message/outbox/retry.go`:
+
+```go
+package outbox
+
+import "time"
+
+type RetryPolicy interface {
+	NextAttempt(record Record, err error, now time.Time) RetryDecision
+}
+
+type RetryDecision struct {
+	Retry         bool
+	NextAttemptAt time.Time
+	Reason        string
+}
+
+type NoRetryPolicy struct{}
+
+func (NoRetryPolicy) NextAttempt(_ Record, err error, _ time.Time) RetryDecision {
+	return RetryDecision{Reason: errorReason(err)}
+}
+
+type FixedBackoffPolicy struct {
+	MaxAttempts int
+	Backoff     time.Duration
+}
+
+func (p FixedBackoffPolicy) NextAttempt(record Record, err error, now time.Time) RetryDecision {
+	decision := RetryDecision{Reason: errorReason(err)}
+	if p.MaxAttempts > 0 && record.Attempts >= p.MaxAttempts {
+		return decision
+	}
+	decision.Retry = true
+	decision.NextAttemptAt = now.Add(p.Backoff)
+	return decision
+}
+
+func errorReason(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+```
+
+- [ ] **Step 4: Run retry tests and verify they pass**
+
+Run: `go test ./ddd/message/outbox -run 'Test.*Policy' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ddd/message/outbox
+git commit -m "feat: add outbox retry policies"
+```
+
+## Task 5: Relay RunOnce
+
+**Files:**
+- Create: `ddd/message/outbox/relay.go`
+- Test: `ddd/message/outbox/relay_test.go`
+
+- [ ] **Step 1: Write failing `RunOnce` tests**
+
+Create `ddd/message/outbox/relay_test.go` with these test cases:
+
+```go
+// Relay must publish claimed records and mark successful records as published so
+// they are not claimed again.
+func TestRelayRunOncePublishesAndMarksPublished(t *testing.T) {
+	store := &relayStore{claimed: []outbox.Record{validRecord(t)}}
+	codec := registeredCodec(t)
+	publisher := &relayPublisher{}
+	relay, err := outbox.NewRelay(store, codec, publisher, outbox.WithClock(fixedClock))
+	require.NoError(t, err)
+
+	result := relay.RunOnce(context.Background(), validClaimOptions())
+
+	require.Equal(t, 1, result.Claimed)
+	require.Equal(t, 1, result.Published)
+	require.Empty(t, result.Errors)
+	require.Len(t, publisher.messages, 1)
+	require.Equal(t, []string{"record-1"}, store.published)
+}
+
+// Decode failures must be persisted through MarkFailed so corrupted records do
+// not disappear from operational visibility.
+func TestRelayRunOnceMarksDecodeFailure(t *testing.T) {
+	store := &relayStore{claimed: []outbox.Record{{ID: "record-1", MessageID: "message-1", Kind: "missing.kind", Attempts: 1}}}
+	relay, err := outbox.NewRelay(store, outbox.NewProtoCodec(), &relayPublisher{}, outbox.WithClock(fixedClock))
+	require.NoError(t, err)
+
+	result := relay.RunOnce(context.Background(), validClaimOptions())
+
+	require.Equal(t, 1, result.Claimed)
+	require.Equal(t, 1, result.Failed)
+	require.True(t, store.failed[0].nextAttemptAt.IsZero())
+	require.Contains(t, store.failed[0].reason, "unknown message kind")
+}
+
+// Publish failures must use the configured retry policy and persist the next
+// attempt time.
+func TestRelayRunOnceRetriesPublishFailure(t *testing.T) {
+	store := &relayStore{claimed: []outbox.Record{validRecord(t)}}
+	publisher := &relayPublisher{err: errors.New("broker unavailable")}
+	relay, err := outbox.NewRelay(
+		store,
+		registeredCodec(t),
+		publisher,
+		outbox.WithClock(fixedClock),
+		outbox.WithRetryPolicy(outbox.FixedBackoffPolicy{MaxAttempts: 3, Backoff: time.Minute}),
+	)
+	require.NoError(t, err)
+
+	result := relay.RunOnce(context.Background(), validClaimOptions())
+
+	require.Equal(t, 1, result.Failed)
+	require.Equal(t, fixedClock().Add(time.Minute), store.failed[0].nextAttemptAt)
+	require.Equal(t, "broker unavailable", store.failed[0].reason)
+}
+
+// MarkPublished failures must be reported because the message may be delivered
+// again after the processing lock expires.
+func TestRelayRunOnceReportsMarkPublishedFailure(t *testing.T) {
+	store := &relayStore{claimed: []outbox.Record{validRecord(t)}, markPublishedErr: errors.New("db down")}
+	relay, err := outbox.NewRelay(store, registeredCodec(t), &relayPublisher{}, outbox.WithClock(fixedClock))
+	require.NoError(t, err)
+
+	result := relay.RunOnce(context.Background(), validClaimOptions())
+
+	require.Equal(t, 1, result.Claimed)
+	require.Zero(t, result.Published)
+	require.Len(t, result.Errors, 1)
+	require.Contains(t, result.Errors[0].Error(), "db down")
+}
+```
+
+Add fakes and helpers in the same file. Use real `ProtoCodec`, real
+`message.Message`, and real protobuf payloads. The import block for
+`relay_test.go` should include:
+
+```go
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message"
+	"github.com/go-jimu/components/ddd/message/outbox"
+	testdata "github.com/go-jimu/components/encoding/testdata"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+```
+
+Use these fakes and helpers:
+
+```go
+type relayStore struct {
+	claimed          []outbox.Record
+	claimErr         error
+	markPublishedErr error
+	markFailedErr    error
+	published        []string
+	failed           []failedRecord
+}
+
+type failedRecord struct {
+	id            string
+	reason        string
+	nextAttemptAt time.Time
+}
+
+func (s *relayStore) Append(context.Context, ...outbox.Record) error { return nil }
+func (s *relayStore) Claim(context.Context, outbox.ClaimOptions) ([]outbox.Record, error) {
+	if s.claimErr != nil {
+		return nil, s.claimErr
+	}
+	return s.claimed, nil
+}
+func (s *relayStore) MarkPublished(_ context.Context, ids ...string) error {
+	if s.markPublishedErr != nil {
+		return s.markPublishedErr
+	}
+	s.published = append(s.published, ids...)
+	return nil
+}
+func (s *relayStore) MarkFailed(_ context.Context, id string, reason string, nextAttemptAt time.Time) error {
+	if s.markFailedErr != nil {
+		return s.markFailedErr
+	}
+	s.failed = append(s.failed, failedRecord{id: id, reason: reason, nextAttemptAt: nextAttemptAt})
+	return nil
+}
+
+type relayPublisher struct {
+	messages []message.Message
+	err      error
+}
+
+func (p *relayPublisher) Publish(_ context.Context, msg message.Message) error {
+	if p.err != nil {
+		return p.err
+	}
+	p.messages = append(p.messages, msg)
+	return nil
+}
+
+func fixedClock() time.Time {
+	return time.Date(2026, 5, 10, 12, 0, 0, 0, time.UTC)
+}
+
+func validClaimOptions() outbox.ClaimOptions {
+	return outbox.ClaimOptions{
+		Limit:       10,
+		LockedUntil: fixedClock().Add(time.Minute),
+		ClaimedBy:   "worker-1",
+	}
+}
+
+func registeredCodec(t *testing.T) *outbox.ProtoCodec {
+	t.Helper()
+	codec := outbox.NewProtoCodec()
+	require.NoError(t, codec.Register("test.test_model", func() proto.Message {
+		return &testdata.TestModel{}
+	}))
+	return codec
+}
+
+func validRecord(t *testing.T) outbox.Record {
+	t.Helper()
+	msg, err := message.New(
+		"test.test_model",
+		&testdata.TestModel{Id: 7, Name: "paid"},
+		message.WithID("message-1"),
+		message.WithKey("order-7"),
+		message.WithOccurredAt(fixedClock()),
+	)
+	require.NoError(t, err)
+	record, err := registeredCodec(t).Encode(msg)
+	require.NoError(t, err)
+	record.ID = "record-1"
+	record.Attempts = 1
+	return record
+}
+```
+
+- [ ] **Step 2: Run relay tests and verify they fail**
+
+Run: `go test ./ddd/message/outbox -run 'TestRelayRunOnce' -count=1`
+
+Expected: FAIL because `Relay` is not defined.
+
+- [ ] **Step 3: Implement relay constructor and `RunOnce`**
+
+Create `ddd/message/outbox/relay.go`:
+
+```go
+package outbox
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-jimu/components/ddd/message"
+)
+
+type Relay struct {
+	store     Store
+	codec     Codec
+	publisher message.Publisher
+	retry     RetryPolicy
+	now       func() time.Time
+}
+
+type relayConfig struct {
+	retry RetryPolicy
+	now   func() time.Time
+}
+
+type RelayOption func(*relayConfig)
+
+func WithRetryPolicy(policy RetryPolicy) RelayOption {
+	return func(cfg *relayConfig) {
+		if policy != nil {
+			cfg.retry = policy
+		}
+	}
+}
+
+func WithClock(now func() time.Time) RelayOption {
+	return func(cfg *relayConfig) {
+		if now != nil {
+			cfg.now = now
+		}
+	}
+}
+
+func NewRelay(store Store, codec Codec, publisher message.Publisher, opts ...RelayOption) (*Relay, error) {
+	if store == nil {
+		return nil, ErrNilStore
+	}
+	if codec == nil {
+		return nil, ErrNilCodec
+	}
+	if publisher == nil {
+		return nil, ErrNilPublisher
+	}
+	cfg := relayConfig{retry: NoRetryPolicy{}, now: time.Now}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return &Relay{store: store, codec: codec, publisher: publisher, retry: cfg.retry, now: cfg.now}, nil
+}
+
+type RunResult struct {
+	Claimed   int
+	Published int
+	Failed    int
+	Errors    []error
+}
+
+func (r *Relay) RunOnce(ctx context.Context, opts ClaimOptions) RunResult {
+	opts, err := opts.normalize(r.now)
+	if err != nil {
+		return RunResult{Errors: []error{err}}
+	}
+	records, err := r.store.Claim(ctx, opts)
+	if err != nil {
+		return RunResult{Errors: []error{err}}
+	}
+	result := RunResult{Claimed: len(records)}
+	for _, record := range records {
+		msg, err := r.codec.Decode(record)
+		if err != nil {
+			r.markFailed(ctx, &result, record, err)
+			continue
+		}
+		if err := r.publisher.Publish(ctx, msg); err != nil {
+			r.markFailed(ctx, &result, record, err)
+			continue
+		}
+		if err := r.store.MarkPublished(ctx, record.ID); err != nil {
+			result.Errors = append(result.Errors, err)
+			continue
+		}
+		result.Published++
+	}
+	return result
+}
+
+func (r *Relay) markFailed(ctx context.Context, result *RunResult, record Record, cause error) {
+	decision := r.retry.NextAttempt(record, cause, r.now())
+	nextAttemptAt := time.Time{}
+	if decision.Retry {
+		nextAttemptAt = decision.NextAttemptAt
+	}
+	if err := r.store.MarkFailed(ctx, record.ID, decision.Reason, nextAttemptAt); err != nil {
+		result.Errors = append(result.Errors, err)
+		return
+	}
+	result.Failed++
+}
+```
+
+- [ ] **Step 4: Run relay `RunOnce` tests and verify they pass**
+
+Run: `go test ./ddd/message/outbox -run 'TestRelayRunOnce' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ddd/message/outbox
+git commit -m "feat: add outbox relay run once"
+```
+
+## Task 6: Relay Run Loop
+
+**Files:**
+- Modify: `ddd/message/outbox/relay.go`
+- Modify: `ddd/message/outbox/relay_test.go`
+
+- [ ] **Step 1: Write failing run-loop tests**
+
+Append these tests to `ddd/message/outbox/relay_test.go`:
+
+```go
+// Run must reject non-positive intervals so callers do not accidentally create
+// tight loops.
+func TestRelayRunRejectsInvalidInterval(t *testing.T) {
+	relay, err := outbox.NewRelay(&relayStore{}, registeredCodec(t), &relayPublisher{})
+	require.NoError(t, err)
+
+	err = relay.Run(context.Background(), outbox.RunOptions{})
+
+	require.True(t, errors.Is(err, outbox.ErrInvalidRunOptions))
+}
+
+// Run must call RunOnce repeatedly and stop when the context is canceled.
+func TestRelayRunStopsOnContextCancellation(t *testing.T) {
+	store := &relayStore{}
+	relay, err := outbox.NewRelay(store, registeredCodec(t), &relayPublisher{}, outbox.WithClock(fixedClock))
+	require.NoError(t, err)
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+
+	err = relay.Run(ctx, outbox.RunOptions{
+		Claim:    validClaimOptions(),
+		Interval: time.Millisecond,
+		OnResult: func(outbox.RunResult) {
+			calls++
+			cancel()
+		},
+	})
+
+	require.ErrorIs(t, err, context.Canceled)
+	require.Equal(t, 1, calls)
+}
+```
+
+- [ ] **Step 2: Run run-loop tests and verify they fail**
+
+Run: `go test ./ddd/message/outbox -run 'TestRelayRun' -count=1`
+
+Expected: FAIL because `RunOptions` and `Run` are not defined.
+
+- [ ] **Step 3: Implement `RunOptions` and `Run`**
+
+Append to `ddd/message/outbox/relay.go`:
+
+```go
+type RunOptions struct {
+	Claim    ClaimOptions
+	Interval time.Duration
+	OnResult func(RunResult)
+}
+
+func (r *Relay) Run(ctx context.Context, opts RunOptions) error {
+	if opts.Interval <= 0 {
+		return ErrInvalidRunOptions
+	}
+	for {
+		result := r.RunOnce(ctx, opts.Claim)
+		if opts.OnResult != nil {
+			opts.OnResult(result)
+		}
+		timer := time.NewTimer(opts.Interval)
+		select {
+		case <-ctx.Done():
+			if !timer.Stop() {
+				select {
+				case <-timer.C:
+				default:
+				}
+			}
+			return ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run run-loop tests and verify they pass**
+
+Run: `go test ./ddd/message/outbox -run 'TestRelayRun' -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ddd/message/outbox
+git commit -m "feat: add outbox relay loop"
+```
+
+## Task 7: Full Verification
+
+**Files:**
+- Verify: `ddd/message/outbox/*.go`
+- Verify: `ddd/message/outbox/*_test.go`
+
+- [ ] **Step 1: Format all new files**
+
+Run: `gofmt -w ddd/message/outbox`
+
+Expected: command exits 0.
+
+- [ ] **Step 2: Run focused package tests**
+
+Run: `go test ./ddd/message/outbox -count=1`
+
+Expected: PASS.
+
+- [ ] **Step 3: Run all Go tests**
+
+Run: `go test ./...`
+
+Expected: PASS.
+
+- [ ] **Step 4: Run repository test target**
+
+Run: `make test`
+
+Expected: PASS.
+
+- [ ] **Step 5: Check diff hygiene**
+
+Run: `git diff --check`
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 6: Final commit if formatting or cleanup changed files**
+
+```bash
+git status --short
+git add ddd/message/outbox
+git commit -m "test: verify message outbox"
+```
+
+If `git status --short` is empty, skip this commit.
+
+## Self-Review Notes
+
+- Spec coverage: record lifecycle, codec, recorder, store claim options, retry,
+  relay `RunOnce`, relay `Run`, at-least-once mark failure behavior, and tests
+  are covered.
+- Scope: SQL store, schema, broker adapters, DLQ, exponential backoff, and
+  domain event outbox remain excluded.
+- Type consistency: the plan uses `Record`, `Status`, `Store`, `ClaimOptions`,
+  `Codec`, `ProtoCodec`, `Recorder`, `StoreRecorder`, `RetryPolicy`,
+  `RunResult`, and `RunOptions` exactly as named in the spec.

--- a/docs/superpowers/specs/2026-05-10-message-outbox-design.md
+++ b/docs/superpowers/specs/2026-05-10-message-outbox-design.md
@@ -1,0 +1,547 @@
+# Integration Message Outbox Design
+
+Date: 2026-05-10
+Status: Draft for review
+
+## Purpose
+
+Add an outbox abstraction for reliable integration message publishing.
+
+The module is:
+
+```text
+ddd/message/outbox
+```
+
+This module builds on `ddd/message.Message`. It records integration messages in
+the caller's business transaction, then publishes them later through a relay.
+
+The goal is at-least-once delivery for integration messages. Exactly-once
+delivery is not a goal; consumers must remain idempotent by `message.ID`.
+
+## Scope
+
+`ddd/message/outbox` covers:
+
+- transaction-time recording of integration messages
+- durable outbox record lifecycle modeling
+- store interfaces for append, claim, publish marking, and failure marking
+- protobuf encode/decode support for `message.Message`
+- relay loops that publish through `message.Publisher`
+- basic retry policies
+
+It does not cover:
+
+- a domain event outbox
+- changes to `ddd/event`
+- changes to `ddd/message`
+- a concrete SQL store implementation
+- database migrations or table DDL
+- concrete Kafka, RabbitMQ, or ConnectRPC adapters
+- dead-letter queues
+- exponential backoff
+- an in-memory store
+
+## Architecture Gate
+
+- Gate level: Level 3, because this introduces a new reliability subpackage,
+  explicit lifecycle states, and a durable integration-message delivery
+  boundary.
+- Bounded context / business capability: shared component library capability for
+  transactional reliability of integration messages across bounded contexts or
+  services.
+- Stable language / data authority: `message.Message` is the integration DTO
+  contract. `outbox.Record` is a durable delivery lifecycle record for that
+  message. The outbox store is the authority for record status, attempts, lock
+  ownership, and retry schedule.
+- Affected aggregate, policy, or service: no business aggregate. Affects message
+  recording, outbox persistence contracts, relay publishing, retry policy,
+  protobuf encoding, and store claim/mark semantics.
+- Invariants and rules: recording must happen in the same business transaction
+  as the business state change; `Recorder` never publishes directly; `Claim`
+  must atomically lock records for one worker; relay delivery is at-least-once;
+  duplicate publishes are possible when publish succeeds but marking published
+  fails; consumers must deduplicate by `Message.ID`.
+- Technical capability classification: transaction-time recording is
+  application transaction-boundary support; store locking, relay loops, codecs,
+  retry, and broker publishing are infrastructure/runtime concerns; no domain
+  invariant is owned by this module.
+- Layer ownership: Domain owns domain events and aggregate state. Application
+  owns mapping selected domain facts to integration messages and calling
+  `Recorder` inside the transaction. Infrastructure owns outbox storage,
+  locking, relay execution, and broker adapters.
+- Proceed / Stop: proceed with design only. Implementation requires a separate
+  plan.
+
+## Concept Model
+
+### Message vs Record
+
+`message.Message` is the integration DTO plus transport-neutral metadata:
+
+```text
+ID, Kind, Key, OccurredAt, Payload, Headers
+```
+
+`outbox.Record` is the durable delivery state for one message:
+
+```text
+Record.ID, MessageID, payload bytes, status, attempts, locks, errors, timestamps
+```
+
+The IDs are deliberately separate:
+
+- `Record.ID` identifies the outbox row or stored lifecycle record. Store
+  methods use it for claim, mark published, and mark failed operations.
+- `MessageID` preserves `message.Message.ID()` for idempotency, deduplication,
+  correlation, and consumer-side safety.
+
+### Event to Message to Outbox
+
+An integration message often comes from a domain event, but the types and
+lifecycles are different:
+
+```text
+aggregate method
+  -> ddd/event.Event collected by aggregate
+  -> application saves aggregate
+  -> application maps selected event/fact to protobuf DTO
+  -> ddd/message.Message
+  -> outbox.Recorder.Record inside the same business transaction
+  -> outbox.Relay publishes later through message.Publisher
+```
+
+If the application saves the aggregate, commits, and only then maps and records
+the message, a crash between those steps can still lose the integration message.
+The reliable path is to append the outbox record before the business transaction
+commits.
+
+This module does not require `ddd/event` to become durable. It requires
+applications that need reliable integration publishing to map the relevant fact
+to `message.Message` and append the outbox record in the same transaction as the
+business write.
+
+## Package Boundary
+
+Proposed package:
+
+```go
+package outbox
+```
+
+The package imports `ddd/message` and protobuf packages. `ddd/message` does not
+import `outbox`, and `ddd/event` does not import either package.
+
+The public API is split into two layers:
+
+- `Recorder`: application-facing transaction-time API.
+- `Store`, `Relay`, `Codec`, and `RetryPolicy`: infrastructure/runtime APIs.
+
+## Record API
+
+`Record` uses exported fields so external store implementations can scan rows,
+construct records, and persist lifecycle changes without reflection or package
+private hooks.
+
+```go
+type Status string
+
+const (
+    StatusPending    Status = "pending"
+    StatusProcessing Status = "processing"
+    StatusPublished  Status = "published"
+    StatusFailed     Status = "failed"
+)
+
+type Record struct {
+    ID         string
+    MessageID  string
+    Kind       message.Kind
+    Key        string
+    OccurredAt time.Time
+    Payload    []byte
+    Headers    map[string]string
+
+    Status        Status
+    Attempts      int
+    NextAttemptAt time.Time
+    LockedUntil   time.Time
+    ClaimedBy     string
+    LastError     string
+    CreatedAt     time.Time
+    UpdatedAt     time.Time
+}
+
+func (r Record) Clone() Record
+```
+
+`Clone` copies `Payload` and `Headers` so callers can safely hold or mutate a
+record copy without changing the original record value.
+
+### Record Fields
+
+| Field | Meaning |
+| --- | --- |
+| `ID` | Durable outbox record ID. |
+| `MessageID` | Original integration message ID. |
+| `Kind` | Integration message contract kind. |
+| `Key` | Ordering or routing group copied from `message.Message`. |
+| `OccurredAt` | Business fact time copied from `message.Message`. |
+| `Payload` | Encoded protobuf bytes. |
+| `Headers` | Message headers copied from `message.Message`. |
+| `Status` | Delivery lifecycle status. |
+| `Attempts` | Number of claim attempts, incremented by `Store.Claim`. |
+| `NextAttemptAt` | Next retry time for failed records. Zero means terminal failure when status is `failed`. |
+| `LockedUntil` | Worker lock expiry for processing records. |
+| `ClaimedBy` | Worker identifier that claimed the record. |
+| `LastError` | Last decode, publish, mark, or retry error reason. |
+| `CreatedAt` | Record creation time. |
+| `UpdatedAt` | Last record update time. |
+
+## Recorder API
+
+```go
+type Recorder interface {
+    Record(ctx context.Context, messages ...message.Message) error
+}
+
+type StoreRecorder struct {
+    // unexported fields
+}
+
+func NewRecorder(store Store, codec Codec, opts ...RecorderOption) (*StoreRecorder, error)
+```
+
+`Recorder.Record` encodes messages into records and appends them to the store.
+It does not publish messages.
+
+`StoreRecorder` is the default implementation:
+
+```text
+message.Message -> Codec.Encode -> Store.Append
+```
+
+The caller is responsible for passing a `Store` implementation that participates
+in the current business transaction. For example, a SQL implementation may bind
+the store to the same transaction object used by the aggregate repository.
+
+The API deliberately does not define a `UnitOfWork` or transaction manager in
+this first version. Different applications already manage transactions in
+different ways, and this module only needs the semantic contract:
+
+```text
+business write + Store.Append(outbox records) commit together
+```
+
+## Store API
+
+```go
+type Store interface {
+    Append(ctx context.Context, records ...Record) error
+    Claim(ctx context.Context, opts ClaimOptions) ([]Record, error)
+    MarkPublished(ctx context.Context, ids ...string) error
+    MarkFailed(ctx context.Context, id string, reason string, nextAttemptAt time.Time) error
+}
+
+type ClaimOptions struct {
+    Limit       int
+    Now         time.Time
+    LockedUntil time.Time
+    ClaimedBy   string
+}
+```
+
+`ClaimOptions` validation rules:
+
+- `Limit` must be greater than zero.
+- `ClaimedBy` must not be empty.
+- `LockedUntil` must be after `Now`.
+- If `Now` is zero, `Relay` fills it from its clock before calling `Store.Claim`.
+
+The caller chooses `LockedUntil`, commonly as `now + lock duration`. This first
+version does not add a separate lock-duration option.
+
+### Append Semantics
+
+`Append` persists new pending records. It must preserve the message metadata and
+encoded payload produced by the codec.
+
+Store implementations should reject records without a record ID, message ID, or
+kind. Zero-length payload bytes are valid for empty protobuf messages. The
+package-level recorder and codec should construct valid records before calling
+the store, but store implementations remain the last persistence boundary.
+
+### Claim Semantics
+
+`Claim` returns records that the caller owns for this processing attempt. It
+must atomically:
+
+- select at most `Limit` claimable records
+- set `Status` to `processing`
+- set `ClaimedBy`
+- set `LockedUntil`
+- increment `Attempts`
+- return the updated records
+
+Claimable records are:
+
+- `pending`
+- `failed` with a non-zero `NextAttemptAt` less than or equal to `Now`
+- `processing` with `LockedUntil` less than or equal to `Now`
+
+Records are not claimable when:
+
+- `status = published`
+- `status = failed` and `NextAttemptAt` is zero
+- `status = processing` and `LockedUntil` is still in the future
+
+Allowed lifecycle transitions are:
+
+- `pending -> processing -> published`
+- `pending -> processing -> failed`
+- `failed -> processing` when `NextAttemptAt` is due
+- `processing -> processing` when the old lock has expired and a new worker
+  reclaims the record
+
+Concurrent workers must not claim the same unexpired record. SQL
+implementations will usually need row-level locks such as
+`SELECT ... FOR UPDATE SKIP LOCKED`, or an equivalent atomic update-and-return
+strategy.
+
+### Mark Semantics
+
+`MarkPublished` marks claimed records as `published`. It accepts multiple record
+IDs so a relay can batch state updates when an implementation supports it.
+
+`MarkFailed` marks one record as `failed`, stores the reason, and sets the retry
+schedule:
+
+- non-zero `nextAttemptAt` means the record can be retried after that time
+- zero `nextAttemptAt` means terminal failure
+
+The store should update `UpdatedAt` on all lifecycle changes.
+
+## Codec API
+
+```go
+type Codec interface {
+    Encode(message.Message) (Record, error)
+    Decode(Record) (message.Message, error)
+}
+
+type ProtoCodec struct {
+    // unexported registry
+}
+
+func NewProtoCodec() *ProtoCodec
+func (c *ProtoCodec) Register(kind message.Kind, factory func() proto.Message) error
+func (c *ProtoCodec) Encode(msg message.Message) (Record, error)
+func (c *ProtoCodec) Decode(record Record) (message.Message, error)
+```
+
+`Encode` marshals the protobuf payload and creates a `Record` with:
+
+- generated `Record.ID`
+- copied `MessageID`
+- copied `Kind`, `Key`, `OccurredAt`, and `Headers`
+- `StatusPending`
+- `CreatedAt` and `UpdatedAt`
+
+`Decode` looks up the factory registered for `record.Kind`, unmarshals
+`record.Payload`, and reconstructs a `message.Message` with the original ID,
+key, occurred time, and headers.
+
+The registry is required because decoding only has bytes plus `Kind`; protobuf
+cannot instantiate arbitrary message types without a known type registry or
+factory.
+
+Expected codec errors include:
+
+- empty kind during registration
+- nil factory during registration
+- unknown kind during decode
+- nil protobuf payload during encode
+- protobuf marshal or unmarshal failure
+
+## Errors
+
+The package should expose sentinel errors for validation and configuration
+failures:
+
+```go
+var (
+    ErrNilStore            = errors.New("outbox: nil store")
+    ErrNilCodec            = errors.New("outbox: nil codec")
+    ErrNilPublisher        = errors.New("outbox: nil publisher")
+    ErrInvalidClaimOptions = errors.New("outbox: invalid claim options")
+    ErrUnknownKind         = errors.New("outbox: unknown message kind")
+)
+```
+
+Concrete implementations may wrap these errors with more detail.
+
+## Retry API
+
+```go
+type RetryPolicy interface {
+    NextAttempt(record Record, err error, now time.Time) RetryDecision
+}
+
+type RetryDecision struct {
+    Retry         bool
+    NextAttemptAt time.Time
+    Reason        string
+}
+
+type NoRetryPolicy struct{}
+
+type FixedBackoffPolicy struct {
+    MaxAttempts int
+    Backoff     time.Duration
+}
+```
+
+`NoRetryPolicy` is the default. It returns `Retry=false`, making failures
+terminal.
+
+`FixedBackoffPolicy` retries with a fixed delay:
+
+- `MaxAttempts <= 0` means unlimited attempts.
+- `Backoff <= 0` means immediate retry.
+- `RetryPolicy` receives the record after `Store.Claim` has incremented
+  `Attempts`.
+- `FixedBackoffPolicy` stops retrying when
+  `MaxAttempts > 0 && record.Attempts >= MaxAttempts`.
+
+This attempts rule treats `MaxAttempts` as total delivery attempts, including
+the current attempt.
+
+## Relay API
+
+```go
+type Relay struct {
+    // unexported fields
+}
+
+type RelayOption func(*relayConfig)
+
+func NewRelay(store Store, codec Codec, publisher message.Publisher, opts ...RelayOption) (*Relay, error)
+
+func WithRetryPolicy(policy RetryPolicy) RelayOption
+func WithClock(now func() time.Time) RelayOption
+
+type RunResult struct {
+    Claimed   int
+    Published int
+    Failed    int
+    Errors    []error
+}
+
+func (r *Relay) RunOnce(ctx context.Context, opts ClaimOptions) RunResult
+
+type RunOptions struct {
+    Claim    ClaimOptions
+    Interval time.Duration
+    OnResult func(RunResult)
+}
+
+func (r *Relay) Run(ctx context.Context, opts RunOptions) error
+```
+
+### RunOnce Semantics
+
+`RunOnce` processes one batch:
+
+```text
+Store.Claim
+  -> for each record:
+       Codec.Decode
+       Publisher.Publish
+       Store.MarkPublished on success
+       RetryPolicy + Store.MarkFailed on failure
+```
+
+If `Store.Claim` fails, `RunOnce` returns a result containing the error and does
+not continue.
+
+If decode or publish fails, the relay calls the retry policy and then
+`MarkFailed`. A retry decision with `Retry=true` passes a non-zero
+`NextAttemptAt`; a terminal decision passes a zero `NextAttemptAt`.
+
+If `MarkPublished` fails after a successful publish, the result records the
+error. The message may be published again after the processing lock expires.
+This is the core at-least-once tradeoff.
+
+If `MarkFailed` fails, the result records the error. The record may be claimed
+again after the processing lock expires because the store still sees it as
+`processing`.
+
+`RunResult.Errors` is a collection of operational errors. `RunOnce` does not
+return a single error because a batch can partially succeed.
+
+### Run Semantics
+
+`Run` repeatedly calls `RunOnce` until the context is canceled.
+
+Rules:
+
+- `Interval` must be greater than zero.
+- Each loop calls `OnResult` when provided.
+- Context cancellation stops the loop and returns the context error.
+- Relay workers are independent; concurrency safety depends on Store.Claim's
+  atomic claim implementation.
+
+## Failure And Delivery Semantics
+
+The module provides at-least-once publishing:
+
+- append succeeds only if the business transaction commits
+- relay may publish the same message more than once
+- consumers must use `message.ID` for idempotency and deduplication
+- message ordering is transport-dependent
+
+`message.Key` is preserved in the record so broker adapters can map it to
+transport-specific ordering keys, such as a Kafka message key. The outbox module
+does not enforce ordering by itself. Store implementations and relays that need
+per-key ordering must document their query and concurrency strategy.
+
+## Expected File Layout
+
+```text
+ddd/message/outbox/
+  doc.go
+  errors.go
+  record.go
+  recorder.go
+  store.go
+  codec.go
+  retry.go
+  relay.go
+```
+
+## Testing Strategy
+
+Implementation should cover behavior at the package boundary:
+
+- record cloning copies mutable fields
+- recorder encodes and appends messages without publishing
+- codec round-trips protobuf payloads and preserves metadata
+- codec rejects unknown kinds, nil factories, and invalid payloads
+- retry policies produce terminal and retry decisions at attempt boundaries
+- relay handles claim failure, decode failure, publish failure, mark failure,
+  and partial success
+- relay uses `MarkFailed` with zero `NextAttemptAt` for terminal failures
+- relay uses non-zero `NextAttemptAt` for retryable failures
+- `Run` rejects non-positive intervals and stops on context cancellation
+
+Store implementation tests belong with each concrete store. A SQL store should
+prove atomic claim behavior under concurrent workers.
+
+## Compatibility
+
+This design is additive. It does not change the existing `ddd/event` or
+`ddd/message` APIs.
+
+Existing direct `message.Publisher` implementations continue to work. The relay
+uses the same publisher interface and therefore can publish through any direct
+publisher that accepts the standard `message.Message` struct.

--- a/docs/superpowers/specs/2026-05-10-message-outbox-design.md
+++ b/docs/superpowers/specs/2026-05-10-message-outbox-design.md
@@ -239,8 +239,8 @@ business write + Store.Append(outbox records) commit together
 type Store interface {
     Append(ctx context.Context, records ...Record) error
     Claim(ctx context.Context, opts ClaimOptions) ([]Record, error)
-    MarkPublished(ctx context.Context, ids ...string) error
-    MarkFailed(ctx context.Context, id string, reason string, nextAttemptAt time.Time) error
+    MarkPublished(ctx context.Context, records ...Record) error
+    MarkFailed(ctx context.Context, record Record, reason string, nextAttemptAt time.Time) error
 }
 
 type ClaimOptions struct {
@@ -249,6 +249,8 @@ type ClaimOptions struct {
     LockedUntil time.Time
     ClaimedBy   string
 }
+
+func NormalizeClaimOptions(opts ClaimOptions, now func() time.Time) (ClaimOptions, error)
 ```
 
 `ClaimOptions` validation rules:
@@ -260,6 +262,10 @@ type ClaimOptions struct {
 
 The caller chooses `LockedUntil`, commonly as `now + lock duration`. This first
 version does not add a separate lock-duration option.
+
+`NormalizeClaimOptions` is exported so concrete store implementations and relay
+code can share the same validation and defaulting rules instead of duplicating
+claim-option behavior.
 
 ### Append Semantics
 
@@ -310,11 +316,15 @@ strategy.
 
 ### Mark Semantics
 
-`MarkPublished` marks claimed records as `published`. It accepts multiple record
-IDs so a relay can batch state updates when an implementation supports it.
+`MarkPublished` marks claimed records as `published`. It accepts multiple
+records so a relay can batch state updates when an implementation supports it.
+The full record is passed instead of only the record ID so concrete stores can
+verify claim ownership fields such as `ClaimedBy`, `LockedUntil`, or `Attempts`
+before changing lifecycle state.
 
-`MarkFailed` marks one record as `failed`, stores the reason, and sets the retry
-schedule:
+`MarkFailed` marks one claimed record as `failed`, stores the reason, and sets
+the retry schedule. It also receives the full record so concrete stores can
+reject stale workers after lock expiry or reclaim:
 
 - non-zero `nextAttemptAt` means the record can be retried after that time
 - zero `nextAttemptAt` means terminal failure


### PR DESCRIPTION
## Summary
- Add protobuf-first `ddd/message` integration message primitives and router.
- Add `ddd/message/outbox` records, codec, recorder/store contracts, retry policies, and relay loop.
- Document the integration message and outbox designs/plans.

## Test Plan
- `go test ./ddd/message/outbox -count=1`
- `go test -race ./ddd/message/outbox -count=1`
- `go test ./...`
- `make test`
- `git diff --check`