### PR TITLE
Clarify ddd/message provider boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,14 @@ The legacy `mediator` package remains source-compatible for existing users and
 will only receive compatibility fixes. See
 [`docs/mediator-migration.md`](docs/mediator-migration.md) for the semantic
 differences and migration guidance.
+
+## Integration messages
+
+Use `github.com/go-jimu/components/ddd/message` for protobuf integration DTOs
+that cross bounded-context or service boundaries.
+
+`message.Kind` is a semantic message type used for handler routing and payload
+resolution. It is not a broker topic, subject, queue, partition, or offset.
+Provider packages map `Kind`, `Message.ID`, `Message.Key`, `OccurredAt`, and
+headers into their own broker envelopes and own retry, DLQ, ack, and commit
+policy.

--- a/ddd/message/doc.go
+++ b/ddd/message/doc.go
@@ -5,4 +5,16 @@
 // inside a bounded context and are usually dispatched after persistence.
 // Integration messages in this package wrap protobuf payloads with routing and
 // trace metadata for direct publication without transactional guarantees.
+//
+// Message Kind is a semantic contract identifier used for handler routing and
+// payload resolution. It is not a topic, subject, queue, partition, or routing
+// key, although providers may map it to those concepts.
+//
+// Subscriber only means handler registration. Broker runtime concerns such as
+// polling, acknowledgement, offset commit, retry, redelivery, and dead-letter
+// routing belong to provider or application code.
+//
+// Message ID, Kind, OccurredAt, Key, and Headers are transport-neutral fields.
+// Providers decide how to encode them into their own envelopes. This package
+// intentionally does not define Kafka-style header names.
 package message

--- a/ddd/message/errors.go
+++ b/ddd/message/errors.go
@@ -3,10 +3,13 @@ package message
 import "errors"
 
 var (
-	ErrEmptyKind     = errors.New("message kind is empty")
-	ErrNilPayload    = errors.New("message payload is nil")
-	ErrEmptyID       = errors.New("message id is empty")
-	ErrNilHandler    = errors.New("message handler is nil")
-	ErrNoListening   = errors.New("message handler listens to no kinds")
-	ErrUnhandledKind = errors.New("message kind is unhandled")
+	ErrEmptyKind          = errors.New("message kind is empty")
+	ErrNilPayload         = errors.New("message payload is nil")
+	ErrEmptyID            = errors.New("message id is empty")
+	ErrNilHandler         = errors.New("message handler is nil")
+	ErrNoListening        = errors.New("message handler listens to no kinds")
+	ErrUnhandledKind      = errors.New("message kind is unhandled")
+	ErrUnknownKind        = errors.New("unknown message kind")
+	ErrNilPayloadResolver = errors.New("message payload resolver is nil")
+	ErrNilPayloadFactory  = errors.New("message payload factory is nil")
 )

--- a/ddd/message/message.go
+++ b/ddd/message/message.go
@@ -9,8 +9,14 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
+// Kind is the semantic integration message contract type.
+//
+// Kind is used for handler matching and payload resolution. It is not a broker
+// topic, queue, subject, exchange, partition, or routing-key contract. Provider
+// adapters may map a Kind to their own envelope address.
 type Kind string
 
+// Message is a protobuf integration DTO plus transport-neutral metadata.
 type Message struct {
 	id         string
 	kind       Kind
@@ -20,6 +26,7 @@ type Message struct {
 	headers    map[string]string
 }
 
+// New constructs a message with a non-empty kind and protobuf payload.
 func New(kind Kind, payload proto.Message, opts ...Option) (Message, error) {
 	if kind == "" {
 		return Message{}, ErrEmptyKind
@@ -62,30 +69,37 @@ func New(kind Kind, payload proto.Message, opts ...Option) (Message, error) {
 	}, nil
 }
 
+// ID returns the unique message instance identifier.
 func (m Message) ID() string {
 	return m.id
 }
 
+// Kind returns the semantic message contract type.
 func (m Message) Kind() Kind {
 	return m.kind
 }
 
+// Key returns the transport-neutral ordering or routing group.
 func (m Message) Key() string {
 	return m.key
 }
 
+// OccurredAt returns the time the represented business fact occurred.
 func (m Message) OccurredAt() time.Time {
 	return m.occurredAt
 }
 
+// Payload returns the protobuf DTO payload.
 func (m Message) Payload() proto.Message {
 	return m.payload
 }
 
+// Headers returns a copy of extension metadata headers.
 func (m Message) Headers() map[string]string {
 	return cloneHeaders(m.headers)
 }
 
+// KindOf derives the protobuf full name for payload.
 func KindOf(payload proto.Message) Kind {
 	if isNilPayload(payload) {
 		return ""

--- a/ddd/message/outbox/codec.go
+++ b/ddd/message/outbox/codec.go
@@ -1,8 +1,9 @@
 package outbox
 
 import (
+	"errors"
+	"fmt"
 	"reflect"
-	"sync"
 	"time"
 
 	"github.com/go-jimu/components/ddd/message"
@@ -15,24 +16,46 @@ type Codec interface {
 }
 
 type ProtoCodec struct {
-	mu        sync.RWMutex
-	factories map[message.Kind]func() proto.Message
+	registry *message.PayloadRegistry
+	resolver message.PayloadResolver
 }
 
-func NewProtoCodec() *ProtoCodec {
-	return &ProtoCodec{factories: make(map[message.Kind]func() proto.Message)}
+// ProtoCodecOption configures a protobuf outbox codec.
+type ProtoCodecOption func(*ProtoCodec)
+
+// NewProtoCodec creates a protobuf-backed outbox codec.
+func NewProtoCodec(opts ...ProtoCodecOption) *ProtoCodec {
+	registry := message.NewPayloadRegistry()
+	codec := &ProtoCodec{
+		registry: registry,
+		resolver: registry,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(codec)
+		}
+	}
+	return codec
 }
 
+// WithPayloadResolver makes the codec use resolver when decoding records.
+//
+// The default resolver is the codec's internal registry populated through
+// Register. Supplying a shared resolver lets outbox and broker adapters reuse
+// the same Kind-to-protobuf mapping.
+func WithPayloadResolver(resolver message.PayloadResolver) ProtoCodecOption {
+	return func(codec *ProtoCodec) {
+		if resolver != nil {
+			codec.resolver = resolver
+		}
+	}
+}
+
+// Register adds a protobuf factory to the codec's default payload registry.
 func (c *ProtoCodec) Register(kind message.Kind, factory func() proto.Message) error {
-	if kind == "" {
-		return message.ErrEmptyKind
+	if err := c.registry.Register(kind, factory); err != nil {
+		return mapPayloadResolverError(err)
 	}
-	if factory == nil {
-		return ErrNilFactory
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.factories[kind] = factory
 	return nil
 }
 
@@ -67,15 +90,9 @@ func (c *ProtoCodec) Encode(msg message.Message) (Record, error) {
 }
 
 func (c *ProtoCodec) Decode(record Record) (message.Message, error) {
-	c.mu.RLock()
-	factory := c.factories[record.Kind]
-	c.mu.RUnlock()
-	if factory == nil {
-		return message.Message{}, ErrUnknownKind
-	}
-	payload := factory()
-	if isNilProtoMessage(payload) {
-		return message.Message{}, ErrNilFactory
+	payload, err := c.resolver.Resolve(record.Kind)
+	if err != nil {
+		return message.Message{}, mapPayloadResolverError(err)
 	}
 	if err := proto.Unmarshal(record.Payload, payload); err != nil {
 		return message.Message{}, err
@@ -88,6 +105,17 @@ func (c *ProtoCodec) Decode(record Record) (message.Message, error) {
 		message.WithOccurredAt(record.OccurredAt),
 		message.WithHeaders(record.Headers),
 	)
+}
+
+func mapPayloadResolverError(err error) error {
+	switch {
+	case errors.Is(err, message.ErrUnknownKind):
+		return fmt.Errorf("%w: %w", ErrUnknownKind, err)
+	case errors.Is(err, message.ErrNilPayloadFactory):
+		return fmt.Errorf("%w: %w", ErrNilFactory, err)
+	default:
+		return err
+	}
 }
 
 func isNilProtoMessage(payload proto.Message) bool {

--- a/ddd/message/outbox/codec_test.go
+++ b/ddd/message/outbox/codec_test.go
@@ -46,6 +46,30 @@ func TestProtoCodecRoundTrip(t *testing.T) {
 	require.True(t, proto.Equal(&testdata.TestModel{Id: 7, Name: "paid"}, decoded.Payload()))
 }
 
+// ProtoCodec should be able to reuse the core message payload resolver so
+// outbox and broker adapters do not maintain separate Kind-to-protobuf maps.
+func TestProtoCodecRoundTripWithPayloadResolver(t *testing.T) {
+	registry := message.NewPayloadRegistry()
+	require.NoError(t, registry.Register("test.test_model", func() proto.Message {
+		return &testdata.TestModel{}
+	}))
+	codec := outbox.NewProtoCodec(outbox.WithPayloadResolver(registry))
+	msg, err := message.New(
+		"test.test_model",
+		&testdata.TestModel{Id: 9, Name: "shipped"},
+		message.WithID("message-9"),
+	)
+	require.NoError(t, err)
+
+	record, err := codec.Encode(msg)
+	require.NoError(t, err)
+	decoded, err := codec.Decode(record)
+	require.NoError(t, err)
+
+	require.Equal(t, "message-9", decoded.ID())
+	require.True(t, proto.Equal(&testdata.TestModel{Id: 9, Name: "shipped"}, decoded.Payload()))
+}
+
 // Invalid registry entries must fail before decode time so missing published
 // language registrations are caught near application startup.
 func TestProtoCodecRejectsInvalidRegistration(t *testing.T) {

--- a/ddd/message/resolver.go
+++ b/ddd/message/resolver.go
@@ -1,0 +1,80 @@
+package message
+
+import (
+	"sync"
+
+	"google.golang.org/protobuf/proto"
+)
+
+// PayloadResolver allocates an empty protobuf payload for a message kind.
+//
+// Broker and storage adapters use the returned message as the target for
+// unmarshalling bytes into the protobuf DTO contract identified by Kind.
+type PayloadResolver interface {
+	Resolve(Kind) (proto.Message, error)
+}
+
+// PayloadResolverFunc adapts a function into a PayloadResolver.
+type PayloadResolverFunc func(Kind) (proto.Message, error)
+
+// Resolve calls f(kind).
+func (f PayloadResolverFunc) Resolve(kind Kind) (proto.Message, error) {
+	if f == nil {
+		return nil, ErrNilPayloadResolver
+	}
+	payload, err := f(kind)
+	if err != nil {
+		return nil, err
+	}
+	if isNilPayload(payload) {
+		return nil, ErrNilPayloadFactory
+	}
+	return payload, nil
+}
+
+// PayloadRegistry is an in-memory Kind-to-protobuf factory registry.
+//
+// It is transport-neutral: Kafka topics, RabbitMQ routing keys, NATS subjects,
+// offsets, acknowledgements, retries, and dead-letter behavior belong to
+// provider/application code. The registry only maps a semantic message kind to
+// the protobuf DTO type needed to decode that kind's payload.
+type PayloadRegistry struct {
+	mu        sync.RWMutex
+	factories map[Kind]func() proto.Message
+}
+
+// NewPayloadRegistry creates an empty payload registry.
+func NewPayloadRegistry() *PayloadRegistry {
+	return &PayloadRegistry{factories: make(map[Kind]func() proto.Message)}
+}
+
+// Register associates kind with a factory that returns a new protobuf target.
+func (r *PayloadRegistry) Register(kind Kind, factory func() proto.Message) error {
+	if kind == "" {
+		return ErrEmptyKind
+	}
+	if factory == nil {
+		return ErrNilPayloadFactory
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.factories[kind] = factory
+	return nil
+}
+
+// Resolve returns a fresh protobuf target for kind.
+func (r *PayloadRegistry) Resolve(kind Kind) (proto.Message, error) {
+	r.mu.RLock()
+	factory := r.factories[kind]
+	r.mu.RUnlock()
+	if factory == nil {
+		return nil, ErrUnknownKind
+	}
+
+	payload := factory()
+	if isNilPayload(payload) {
+		return nil, ErrNilPayloadFactory
+	}
+	return payload, nil
+}

--- a/ddd/message/resolver_test.go
+++ b/ddd/message/resolver_test.go
@@ -1,0 +1,97 @@
+package message_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-jimu/components/ddd/message"
+	testdata "github.com/go-jimu/components/encoding/testdata"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// Intent: a payload registry should give adapters a fresh protobuf target for
+// each consumed message kind so decode operations cannot share mutable state.
+func TestPayloadRegistryResolveReturnsFreshPayload(t *testing.T) {
+	registry := message.NewPayloadRegistry()
+	require.NoError(t, registry.Register("test.test_model", func() proto.Message {
+		return &testdata.TestModel{}
+	}))
+
+	first, err := registry.Resolve("test.test_model")
+	require.NoError(t, err)
+	second, err := registry.Resolve("test.test_model")
+	require.NoError(t, err)
+
+	require.IsType(t, &testdata.TestModel{}, first)
+	require.IsType(t, &testdata.TestModel{}, second)
+	require.NotSame(t, first, second)
+}
+
+// Intent: invalid payload registrations should fail near application startup
+// rather than later during broker record decoding.
+func TestPayloadRegistryRejectsInvalidRegistration(t *testing.T) {
+	registry := message.NewPayloadRegistry()
+
+	require.ErrorIs(t, registry.Register("", func() proto.Message {
+		return &testdata.TestModel{}
+	}), message.ErrEmptyKind)
+	require.ErrorIs(t, registry.Register("test.test_model", nil), message.ErrNilPayloadFactory)
+}
+
+// Intent: unknown message kinds should fail clearly because adapters cannot
+// unmarshal bytes without a protobuf target type.
+func TestPayloadRegistryRejectsUnknownKind(t *testing.T) {
+	registry := message.NewPayloadRegistry()
+
+	payload, err := registry.Resolve("missing.kind")
+
+	require.ErrorIs(t, err, message.ErrUnknownKind)
+	require.Nil(t, payload)
+}
+
+// Intent: factories that produce nil must fail before protobuf unmarshalling
+// so adapter misconfiguration does not become a panic.
+func TestPayloadRegistryRejectsNilFactoryOutput(t *testing.T) {
+	registry := message.NewPayloadRegistry()
+	require.NoError(t, registry.Register("test.test_model", func() proto.Message {
+		return nil
+	}))
+
+	payload, err := registry.Resolve("test.test_model")
+
+	require.ErrorIs(t, err, message.ErrNilPayloadFactory)
+	require.Nil(t, payload)
+}
+
+// Intent: typed-nil factory output must be treated as nil, matching message
+// construction and protecting adapters from protobuf nil pointer panics.
+func TestPayloadRegistryRejectsTypedNilFactoryOutput(t *testing.T) {
+	registry := message.NewPayloadRegistry()
+	require.NoError(t, registry.Register("test.test_model", func() proto.Message {
+		var payload *testdata.TestModel
+		return payload
+	}))
+
+	payload, err := registry.Resolve("test.test_model")
+
+	require.True(t, errors.Is(err, message.ErrNilPayloadFactory))
+	require.Nil(t, payload)
+}
+
+// Intent: function-based resolvers should enforce the same nil payload contract
+// as registries so adapters can trust the PayloadResolver interface.
+func TestPayloadResolverFuncRejectsNilOutputs(t *testing.T) {
+	var nilResolver message.PayloadResolverFunc
+	payload, err := nilResolver.Resolve("test.test_model")
+	require.ErrorIs(t, err, message.ErrNilPayloadResolver)
+	require.Nil(t, payload)
+
+	typedNilResolver := message.PayloadResolverFunc(func(message.Kind) (proto.Message, error) {
+		var payload *testdata.TestModel
+		return payload, nil
+	})
+	payload, err = typedNilResolver.Resolve("test.test_model")
+	require.ErrorIs(t, err, message.ErrNilPayloadFactory)
+	require.Nil(t, payload)
+}

--- a/ddd/message/router.go
+++ b/ddd/message/router.go
@@ -9,15 +9,45 @@ type Publisher interface {
 	Publish(context.Context, Message) error
 }
 
+// Handler processes integration messages for the kinds returned by Listening.
+//
+// Handle returns nil when the message has been accepted and fully handled by
+// this handler. A provider may ack, commit, or otherwise mark delivery complete
+// after all matching handlers return nil.
+//
+// A non-nil error means the message was not successfully handled. Providers may
+// apply their own retry, redelivery, dead-letter, stop, or failure-recording
+// policy. Business failures that should not cause redelivery should be handled
+// inside the handler and then return nil.
 type Handler interface {
 	Listening() []Kind
 	Handle(context.Context, Message) error
 }
 
+// Subscriber registers message handlers.
+//
+// Subscribe is a handler registration operation only. It does not imply that a
+// broker consumer has started polling, reserved partitions, acknowledged
+// records, committed offsets, or joined a consumer group. Providers that own a
+// runtime loop should expose that separately, for example by implementing
+// Runner.
 type Subscriber interface {
 	Subscribe(Handler) error
 }
 
+// Runner is an optional runtime loop capability for providers that actively
+// consume messages.
+type Runner interface {
+	Run(context.Context) error
+}
+
+// Closer is an optional lifecycle capability for providers that own resources.
+type Closer interface {
+	Close() error
+}
+
+// Router registers handlers by Kind and dispatches messages to them
+// sequentially.
 type Router struct {
 	mu       sync.RWMutex
 	handlers map[Kind][]Handler
@@ -31,6 +61,9 @@ func NewRouter() *Router {
 	}
 }
 
+// Subscribe registers handler for each non-empty kind returned by Listening.
+//
+// Duplicate kinds from the same handler are ignored.
 func (r *Router) Subscribe(handler Handler) error {
 	if handler == nil {
 		return ErrNilHandler
@@ -63,6 +96,12 @@ func (r *Router) Subscribe(handler Handler) error {
 	return nil
 }
 
+// Handle dispatches msg to all handlers registered for msg.Kind().
+//
+// Handlers run sequentially in subscription order. Routing stops at the first
+// handler error and returns that error so the caller can avoid acknowledging a
+// partially handled message. ErrUnhandledKind is returned when no handler is
+// registered for the message kind.
 func (r *Router) Handle(ctx context.Context, msg Message) error {
 	r.mu.RLock()
 	handlers := append([]Handler(nil), r.handlers[msg.Kind()]...)

--- a/docs/project-knowledge/architecture.md
+++ b/docs/project-knowledge/architecture.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
-triggered_by_plan: 2026-05-10-message-outbox.md
+triggered_by_plan: 2026-05-10-integration-message.md
 ---
 
 # Architecture
@@ -29,7 +29,7 @@ compatible and adds DDD concept packages under `ddd/`.
 - `logger/` and `sloghelper/` — logger adapters and helpers for `log/slog`.
 - `mediator/` — existing in-process event mediator with global default, event collection, subscription, dispatch, and graceful shutdown.
 - `ddd/event/` — DDD-oriented domain event collection, batch dispatch, and handler subscription. Key abstractions: `Event`, `Collection`, `Dispatcher`, `Subscriber`, `InMemoryDispatcher`, `Handler`.
-- `ddd/message/` — protobuf-first integration message DTO construction and deterministic handler routing for cross-context messaging. Key abstractions: `Message`, `Kind`, `Publisher`, `Subscriber`, `Handler`, `Router`.
+- `ddd/message/` — protobuf-first integration message DTO construction, deterministic handler routing, and payload resolution for cross-context messaging. Key abstractions: `Message`, `Kind`, `Publisher`, `Subscriber`, `Handler`, `Router`, `PayloadResolver`, `PayloadRegistry`.
 - `ddd/message/outbox/` — transactional outbox contracts and relay runtime for reliable integration message publishing. Key abstractions: `Record`, `Store`, `Recorder`, `Codec`, `RetryPolicy`, `Relay`.
 - `validation/` — notification and specification validation helpers.
 - `docs/superpowers/specs/` and `docs/superpowers/plans/` — design and implementation records for planned or recently completed work.

--- a/docs/project-knowledge/conventions.md
+++ b/docs/project-knowledge/conventions.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
-triggered_by_plan: 2026-05-10-message-outbox.md
+triggered_by_plan: 2026-05-10-integration-message.md
 ---
 
 # Conventions
@@ -26,6 +26,8 @@ triggered_by_plan: 2026-05-10-message-outbox.md
 - `ddd/message` is for protobuf integration DTOs crossing bounded-context or service boundaries; it must remain separate from `ddd/event`.
 - `ddd/message/outbox` is the reliability subpackage for integration-message outbox contracts and relay runtime; keep it separate from `ddd/message` core DTO/routing APIs and from `ddd/event`.
 - Broker-specific envelope, acknowledgement, DLQ, concrete store, and concrete broker adapter behavior should live outside both `ddd/message` and `ddd/message/outbox`.
+- `message.Kind` is a semantic message contract identifier, not a broker topic/subject/routing-key.
+- `message.Handler.Handle` returning `nil` means provider code may ack/commit; returning an error leaves retry, DLQ, redelivery, or stop policy to the provider/application.
 
 ## Git And CI
 

--- a/docs/project-knowledge/features.md
+++ b/docs/project-knowledge/features.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
-triggered_by_plan: 2026-05-10-message-outbox.md
+triggered_by_plan: 2026-05-10-integration-message.md
 ---
 
 # Features
@@ -83,6 +83,13 @@ triggered_by_plan: 2026-05-10-message-outbox.md
 **Enables** — Consumers route received integration messages to handlers by message kind.
 **Actors / Entry Points** — Consumers register `message.Handler` values through `message.Router` or a `Subscriber`.
 **Capability Boundary** — Router handles in-process handler matching and first-error stop; acknowledgement, offset commit, and broker envelope mapping belong to adapters.
+**References** — `ddd/message/`, `docs/superpowers/specs/2026-05-10-integration-message-design.md`
+
+#### Integration message payload resolution
+
+**Enables** — Consumers and adapters map a semantic message kind to a fresh protobuf DTO target when decoding bytes.
+**Actors / Entry Points** — Provider/application setup code uses `message.PayloadResolver` or `message.PayloadRegistry`.
+**Capability Boundary** — Resolver owns only Kind-to-payload allocation; broker topic/subject mapping, retry, DLQ, acknowledgement, commit, and envelope header encoding stay in provider/application code.
 **References** — `ddd/message/`, `docs/superpowers/specs/2026-05-10-integration-message-design.md`
 
 #### Transactional outbox primitives

--- a/docs/project-knowledge/glossary.md
+++ b/docs/project-knowledge/glossary.md
@@ -1,7 +1,7 @@
 ---
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
-triggered_by_plan: 2026-05-10-message-outbox.md
+triggered_by_plan: 2026-05-10-integration-message.md
 ---
 
 # Glossary
@@ -23,6 +23,8 @@ triggered_by_plan: 2026-05-10-message-outbox.md
 **Message Kind** — Integration message contract identifier used for routing and handler matching. → `ddd/message/`
 
 **Message Key** — Transport-neutral ordering or routing group for an integration message. → `ddd/message/`
+
+**Payload Resolver** — Transport-neutral mapping from `message.Kind` to a fresh protobuf message target for decoding consumed bytes. → `ddd/message/`
 
 **Publisher** — Capability interface that directly hands off an integration message to a messaging runtime. → `ddd/message/`
 

--- a/docs/project-knowledge/index.md
+++ b/docs/project-knowledge/index.md
@@ -1,26 +1,26 @@
 ---
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
-triggered_by_plan: 2026-05-10-message-outbox.md
-covers_branch: release/message@c57db69
+triggered_by_plan: 2026-05-10-integration-message.md
+covers_branch: hotfix/message-api@be00b6c
 ---
 
 # Project Knowledge Index
 
 - [architecture.md](architecture.md) — System boundaries, package layering, and core scenario flows.
-  Key points: component library with independent Go packages; DDD event, message, and message outbox packages live under `ddd/`.
+  Key points: component library with independent Go packages; `ddd/message` covers integration DTOs, routing, and payload resolution while outbox lives separately.
 
 - [tech-stack.md](tech-stack.md) — Languages, frameworks, and key dependencies.
-  Key points: Go 1.24 module; protobuf support comes from `google.golang.org/protobuf`.
+  Key points: Go 1.24.0 module; protobuf support comes from `google.golang.org/protobuf`.
 
 - [features.md](features.md) — Implemented package capabilities and boundaries.
-  Key points: implemented config, encoding, fsm, logging, mediator, DDD event, DDD message, message outbox, and validation capabilities.
+  Key points: `ddd/message` includes protobuf message construction, handler routing, and payload resolution; provider retry/DLQ/ack/commit remain outside core.
 
 - [conventions.md](conventions.md) — Coding, testing, event, message, and CI rules.
-  Key points: keep `mediator`, `ddd/event`, `ddd/message`, and `ddd/message/outbox` responsibilities separate; CI expects `make test`.
+  Key points: keep `mediator`, `ddd/event`, `ddd/message`, and `ddd/message/outbox` responsibilities separate; `message.Kind` is semantic, not a broker address.
 
 - [decisions.md](decisions.md) — Architecture decision summaries and known issues.
   Key points: DDD concepts live under `ddd/`; integration messages are protobuf DTOs separate from domain events.
 
 - [glossary.md](glossary.md) — Project terminology and package ownership.
-  Key points: defines domain event, integration message, message kind/key, publisher/subscriber/router, and outbox lifecycle terms.
+  Key points: defines domain event, integration message, message kind/key, payload resolver, publisher/subscriber/router, and outbox lifecycle terms.

--- a/docs/superpowers/specs/2026-05-10-integration-message-design.md
+++ b/docs/superpowers/specs/2026-05-10-integration-message-design.md
@@ -51,10 +51,11 @@ The module assumes protobuf is the contract format. It may depend directly on
   infrastructure mapping code may convert selected domain events to integration
   messages; handlers consume stable protobuf DTO contracts, not publisher
   internal domain event structs.
-- Technical capability classification: message construction is an application
-  contract concern; publishing, subscribing, broker envelopes, offset commits,
-  acknowledgements, and transport mapping are infrastructure concerns; handler
-  routing is reusable application/runtime orchestration.
+- Technical capability classification: message construction and payload
+  resolution are application contract concerns; publishing, subscribing, broker
+  envelopes, offset commits, acknowledgements, and transport mapping are
+  infrastructure concerns; handler routing is reusable application/runtime
+  orchestration.
 - Layer ownership: Domain owns domain events. Application owns the decision to
   publish an integration message and the mapping from domain facts to protobuf
   DTOs. Infrastructure owns broker-specific publish/consume mechanics.
@@ -137,6 +138,18 @@ type Handler interface {
 type Subscriber interface {
     Subscribe(Handler) error
 }
+
+type Runner interface {
+    Run(context.Context) error
+}
+
+type Closer interface {
+    Close() error
+}
+
+type PayloadResolver interface {
+    Resolve(Kind) (proto.Message, error)
+}
 ```
 
 `Message` is a struct, not an interface, because it is the standard DTO shape.
@@ -144,8 +157,8 @@ Different publishers and handlers should process the same message type. A
 Kafka-backed message must not become a different public type from a
 RabbitMQ-backed message.
 
-`Publisher`, `Subscriber`, and `Handler` are interfaces because they describe
-capabilities.
+`Publisher`, `Subscriber`, `Handler`, `Runner`, `Closer`, and
+`PayloadResolver` are interfaces because they describe capabilities.
 
 ## Message Fields
 
@@ -170,6 +183,11 @@ Fields intentionally not included as first-class API:
   concerns outside this non-transactional core.
 - `ContentType`: the core is protobuf-first, so payload format is already
   constrained by the API.
+
+Header name constants are also intentionally not included in the core API.
+Message ID, Kind, OccurredAt, Key, and Headers are typed fields on
+`message.Message`; each provider decides how to encode them into Kafka headers,
+AMQP properties, NATS headers, or another envelope protocol.
 
 ## Message Construction
 
@@ -234,6 +252,17 @@ Transactional guarantees belong to a future outbox-backed publisher.
 need the broker adapter to choose acknowledgement, offset commit, negative
 acknowledgement, retry, or failure recording behavior.
 
+Return semantics:
+
+- `nil` means the handler accepted and finished processing the message. After
+  all matching handlers return nil, a provider may ack, commit, or otherwise
+  mark the delivery complete.
+- a non-nil error means the message was not successfully handled. A provider may
+  retry, redeliver, publish to DLQ, stop, or record the failure according to its
+  own policy.
+- business failures that should not cause broker redelivery should be handled
+  inside the handler and then return nil.
+
 Handler matching is based on `Kind`:
 
 ```go
@@ -247,6 +276,11 @@ Unlike `ddd/event`, an unhandled integration message should be treated as an
 error by default. A domain event can be optional inside a bounded context, but an
 integration message received from a broker is an external contract that should
 have an explicit consumer or dead-letter/failure policy.
+
+`Subscriber.Subscribe` is handler registration only. It does not start a broker
+consumer, poll records, reserve partitions, join a consumer group, ack records,
+or commit offsets. Providers that own a runtime loop should expose that
+separately, for example by implementing `Runner`.
 
 ## Router
 
@@ -275,6 +309,32 @@ func (r *Router) Handle(context.Context, Message) error
 The first version should keep routing sequential and deterministic. Concurrent
 handling can be introduced later as a separate implementation or option with
 explicitly documented ordering trade-offs.
+
+## Payload Resolution
+
+Consumers that receive broker bytes need a transport-neutral way to allocate the
+protobuf DTO target for a message kind:
+
+```go
+type PayloadResolver interface {
+    Resolve(Kind) (proto.Message, error)
+}
+
+type PayloadRegistry struct {
+    // unexported fields
+}
+
+func NewPayloadRegistry() *PayloadRegistry
+func (r *PayloadRegistry) Register(Kind, func() proto.Message) error
+func (r *PayloadRegistry) Resolve(Kind) (proto.Message, error)
+```
+
+`PayloadRegistry` maps semantic message kinds to protobuf factories. It does
+not know about Kafka topics, NATS subjects, RabbitMQ routing keys, offsets,
+acknowledgements, retries, or dead-letter behavior.
+
+`Resolve` must return a fresh protobuf message each time because unmarshalling
+mutates the target value.
 
 ## Transport Adapter Mapping
 
@@ -317,6 +377,9 @@ var (
     ErrNilHandler    = errors.New("message handler is nil")
     ErrNoListening   = errors.New("message handler listens to no kinds")
     ErrUnhandledKind = errors.New("message kind has no handler")
+    ErrUnknownKind   = errors.New("unknown message kind")
+    ErrNilPayloadResolver = errors.New("message payload resolver is nil")
+    ErrNilPayloadFactory  = errors.New("message payload factory is nil")
 )
 ```
 
@@ -371,6 +434,14 @@ Router tests:
 - `Handle` calls matching handlers in subscription order.
 - `Handle` does not call handlers for other kinds.
 - `Handle` stops and returns the first handler error.
+
+Payload resolver tests:
+
+- `PayloadRegistry.Resolve` returns a fresh protobuf target for a registered
+  kind.
+- `PayloadRegistry` rejects empty kinds and nil factories.
+- `PayloadRegistry.Resolve` rejects unknown kinds and nil factory output,
+  including typed nil protobuf pointers.
 
 Interface conformance tests:
 


### PR DESCRIPTION
## Summary
- Document handler, subscriber, kind, and provider-boundary semantics for ddd/message
- Add transport-neutral payload resolver/registry for Kind-to-protobuf allocation
- Let outbox ProtoCodec reuse a shared payload resolver while keeping existing registration API

## Test Plan
- [x] go test ./...