### PR TITLE
Trim ddd/message lifecycle API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       checks: write
     strategy:
       matrix:
-        go-version: [ 1.23.x, 1.24.x, 1.25.x ]
+        go-version: [ 1.24.x, 1.25.x ]
         os: [ ubuntu-latest ]
       fail-fast: true
     runs-on: ${{matrix.os}}

--- a/ddd/message/errors.go
+++ b/ddd/message/errors.go
@@ -3,13 +3,20 @@ package message
 import "errors"
 
 var (
-	ErrEmptyKind          = errors.New("message kind is empty")
-	ErrNilPayload         = errors.New("message payload is nil")
-	ErrEmptyID            = errors.New("message id is empty")
-	ErrNilHandler         = errors.New("message handler is nil")
-	ErrNoListening        = errors.New("message handler listens to no kinds")
-	ErrUnhandledKind      = errors.New("message kind is unhandled")
-	ErrUnknownKind        = errors.New("unknown message kind")
+	ErrEmptyKind     = errors.New("message kind is empty")
+	ErrNilPayload    = errors.New("message payload is nil")
+	ErrEmptyID       = errors.New("message id is empty")
+	ErrNilHandler    = errors.New("message handler is nil")
+	ErrNoListening   = errors.New("message handler listens to no kinds")
+	ErrUnhandledKind = errors.New("message kind is unhandled")
+	ErrUnknownKind   = errors.New("unknown message kind")
+
+	// ErrNilPayloadResolver means no resolver function was configured.
 	ErrNilPayloadResolver = errors.New("message payload resolver is nil")
-	ErrNilPayloadFactory  = errors.New("message payload factory is nil")
+
+	// ErrNilPayloadFactory means a resolver or registry factory could not
+	// allocate a protobuf target for decoding. It is distinct from
+	// ErrNilPayload, which applies to constructing a Message with an invalid
+	// payload value.
+	ErrNilPayloadFactory = errors.New("message payload factory is nil")
 )

--- a/ddd/message/resolver.go
+++ b/ddd/message/resolver.go
@@ -10,6 +10,8 @@ import (
 //
 // Broker and storage adapters use the returned message as the target for
 // unmarshalling bytes into the protobuf DTO contract identified by Kind.
+// Returning nil or a typed-nil protobuf message is a resolver configuration
+// error reported as ErrNilPayloadFactory.
 type PayloadResolver interface {
 	Resolve(Kind) (proto.Message, error)
 }

--- a/ddd/message/router.go
+++ b/ddd/message/router.go
@@ -41,11 +41,6 @@ type Runner interface {
 	Run(context.Context) error
 }
 
-// Closer is an optional lifecycle capability for providers that own resources.
-type Closer interface {
-	Close() error
-}
-
 // Router registers handlers by Kind and dispatches messages to them
 // sequentially.
 type Router struct {

--- a/docs/project-knowledge/index.md
+++ b/docs/project-knowledge/index.md
@@ -2,7 +2,7 @@
 last_updated: 2026-05-10
 updated_by: superpowers-memory:update
 triggered_by_plan: 2026-05-10-integration-message.md
-covers_branch: hotfix/message-api@be00b6c
+covers_branch: hotfix/enhance@fc2ec99
 ---
 
 # Project Knowledge Index

--- a/docs/superpowers/specs/2026-05-10-integration-message-design.md
+++ b/docs/superpowers/specs/2026-05-10-integration-message-design.md
@@ -143,10 +143,6 @@ type Runner interface {
     Run(context.Context) error
 }
 
-type Closer interface {
-    Close() error
-}
-
 type PayloadResolver interface {
     Resolve(Kind) (proto.Message, error)
 }
@@ -157,8 +153,8 @@ Different publishers and handlers should process the same message type. A
 Kafka-backed message must not become a different public type from a
 RabbitMQ-backed message.
 
-`Publisher`, `Subscriber`, `Handler`, `Runner`, `Closer`, and
-`PayloadResolver` are interfaces because they describe capabilities.
+`Publisher`, `Subscriber`, `Handler`, `Runner`, and `PayloadResolver` are
+interfaces because they describe capabilities.
 
 ## Message Fields
 
@@ -382,6 +378,10 @@ var (
     ErrNilPayloadFactory  = errors.New("message payload factory is nil")
 )
 ```
+
+`ErrNilPayload` applies when constructing a `Message` with an absent protobuf
+payload. `ErrNilPayloadFactory` applies when a resolver or registry factory
+cannot allocate the protobuf target needed to decode consumed bytes.
 
 Concrete publishers and subscribers should wrap transport errors with operation
 context. The core package does not define broker-specific failure categories.


### PR DESCRIPTION
## Summary
- Remove the unused optional message.Closer interface from ddd/message
- Clarify nil payload vs nil payload factory error ownership for resolver-based decoding
- Refresh the integration message design spec and project knowledge index

## Test Plan
- [x] go test ./...