### PR TITLE
Add taskqueue component contracts

### DIFF
--- a/taskqueue/doc.go
+++ b/taskqueue/doc.go
@@ -1,0 +1,13 @@
+// Package taskqueue defines transport-neutral task queue contracts.
+//
+// It models background tasks as semantic Task values, plus provider-neutral
+// capabilities for enqueueing, handler registration, middleware, and runtime
+// loops. It intentionally does not define worker storage, acknowledgement,
+// retry, dead-letter, cron, or locking behavior. Provider adapters map these
+// contracts to their own queue systems.
+//
+// Task Type is a semantic contract identifier used for handler routing. Queue
+// is an optional provider-facing lane name. Providers decide how to encode Type,
+// Queue, Key, Headers, payload bytes, and enqueue options into their own
+// envelopes.
+package taskqueue

--- a/taskqueue/doc.go
+++ b/taskqueue/doc.go
@@ -6,8 +6,8 @@
 // retry, dead-letter, cron, or locking behavior. Provider adapters map these
 // contracts to their own queue systems.
 //
-// Task Type is a semantic contract identifier used for handler routing. Queue
-// is an optional provider-facing lane name. Providers decide how to encode Type,
-// Queue, Key, Headers, payload bytes, and enqueue options into their own
-// envelopes.
+// TaskType is a semantic contract identifier used for schema and processor
+// routing. Queue is an optional provider-facing lane name. Providers decide how
+// to encode TaskType, Queue, Key, Headers, payload bytes, and enqueue options
+// into their own envelopes.
 package taskqueue

--- a/taskqueue/enqueue.go
+++ b/taskqueue/enqueue.go
@@ -1,0 +1,109 @@
+package taskqueue
+
+import (
+	"context"
+	"time"
+)
+
+// Enqueuer hands a task to a task queue provider.
+type Enqueuer interface {
+	Enqueue(context.Context, Task, ...EnqueueOption) error
+}
+
+// EnqueueOption configures transport-neutral enqueue policy.
+type EnqueueOption func(*EnqueueOptions)
+
+// EnqueueOptions carries transport-neutral enqueue policy.
+type EnqueueOptions struct {
+	delay       time.Duration
+	processAt   time.Time
+	maxRetry    int
+	maxRetrySet bool
+	timeout     time.Duration
+	deadline    time.Time
+	uniqueTTL   time.Duration
+}
+
+// NewEnqueueOptions applies opts and returns the resulting enqueue policy.
+func NewEnqueueOptions(opts ...EnqueueOption) EnqueueOptions {
+	cfg := EnqueueOptions{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return cfg
+}
+
+// WithDelay asks the provider to process the task after delay.
+func WithDelay(delay time.Duration) EnqueueOption {
+	return func(cfg *EnqueueOptions) {
+		cfg.delay = delay
+	}
+}
+
+// WithProcessAt asks the provider to process the task at processAt.
+func WithProcessAt(processAt time.Time) EnqueueOption {
+	return func(cfg *EnqueueOptions) {
+		cfg.processAt = processAt
+	}
+}
+
+// WithMaxRetry asks the provider to override its default retry count.
+func WithMaxRetry(maxRetry int) EnqueueOption {
+	return func(cfg *EnqueueOptions) {
+		cfg.maxRetry = maxRetry
+		cfg.maxRetrySet = true
+	}
+}
+
+// WithTimeout asks the provider to bound one handling attempt by timeout.
+func WithTimeout(timeout time.Duration) EnqueueOption {
+	return func(cfg *EnqueueOptions) {
+		cfg.timeout = timeout
+	}
+}
+
+// WithDeadline asks the provider to stop processing the task after deadline.
+func WithDeadline(deadline time.Time) EnqueueOption {
+	return func(cfg *EnqueueOptions) {
+		cfg.deadline = deadline
+	}
+}
+
+// WithUnique asks the provider to suppress duplicates for ttl when supported.
+func WithUnique(ttl time.Duration) EnqueueOption {
+	return func(cfg *EnqueueOptions) {
+		cfg.uniqueTTL = ttl
+	}
+}
+
+// Delay returns the relative processing delay.
+func (o EnqueueOptions) Delay() time.Duration {
+	return o.delay
+}
+
+// ProcessAt returns the absolute processing time.
+func (o EnqueueOptions) ProcessAt() time.Time {
+	return o.processAt
+}
+
+// MaxRetry returns the configured retry count and whether it was explicitly set.
+func (o EnqueueOptions) MaxRetry() (int, bool) {
+	return o.maxRetry, o.maxRetrySet
+}
+
+// Timeout returns the per-attempt timeout.
+func (o EnqueueOptions) Timeout() time.Duration {
+	return o.timeout
+}
+
+// Deadline returns the absolute processing deadline.
+func (o EnqueueOptions) Deadline() time.Time {
+	return o.deadline
+}
+
+// UniqueTTL returns the provider duplicate suppression window.
+func (o EnqueueOptions) UniqueTTL() time.Duration {
+	return o.uniqueTTL
+}

--- a/taskqueue/enqueue_test.go
+++ b/taskqueue/enqueue_test.go
@@ -1,0 +1,56 @@
+package taskqueue
+
+import (
+	"testing"
+	"time"
+)
+
+// Enqueue options should preserve scheduling and retry intent so provider
+// adapters can map application requests without importing provider packages.
+func TestNewEnqueueOptions_CapturesSchedulingAndRetryPolicy(t *testing.T) {
+	processAt := time.Date(2026, 5, 28, 10, 30, 0, 0, time.UTC)
+	opts := NewEnqueueOptions(
+		WithDelay(30*time.Second),
+		WithProcessAt(processAt),
+		WithMaxRetry(0),
+		WithTimeout(5*time.Second),
+		WithDeadline(processAt.Add(time.Minute)),
+		WithUnique(10*time.Minute),
+	)
+
+	if opts.Delay() != 30*time.Second {
+		t.Fatalf("delay = %v", opts.Delay())
+	}
+	if !opts.ProcessAt().Equal(processAt) {
+		t.Fatalf("process at = %v", opts.ProcessAt())
+	}
+	maxRetry, ok := opts.MaxRetry()
+	if !ok || maxRetry != 0 {
+		t.Fatalf("max retry = %d, %t; want 0, true", maxRetry, ok)
+	}
+	if opts.Timeout() != 5*time.Second {
+		t.Fatalf("timeout = %v", opts.Timeout())
+	}
+	if !opts.Deadline().Equal(processAt.Add(time.Minute)) {
+		t.Fatalf("deadline = %v", opts.Deadline())
+	}
+	if opts.UniqueTTL() != 10*time.Minute {
+		t.Fatalf("unique ttl = %v", opts.UniqueTTL())
+	}
+}
+
+// Empty enqueue options should keep zero values and report max retry as unset
+// so adapters can distinguish an explicit zero retry from no policy override.
+func TestNewEnqueueOptions_ReportsUnsetMaxRetry(t *testing.T) {
+	opts := NewEnqueueOptions()
+
+	if retry, ok := opts.MaxRetry(); ok || retry != 0 {
+		t.Fatalf("max retry = %d, %t; want 0, false", retry, ok)
+	}
+	if opts.Delay() != 0 {
+		t.Fatalf("delay = %v", opts.Delay())
+	}
+	if !opts.ProcessAt().IsZero() {
+		t.Fatalf("process at = %v", opts.ProcessAt())
+	}
+}

--- a/taskqueue/errors.go
+++ b/taskqueue/errors.go
@@ -1,0 +1,15 @@
+package taskqueue
+
+import "errors"
+
+var (
+	ErrEmptyType       = errors.New("task type is empty")
+	ErrNilHandler      = errors.New("task handler is nil")
+	ErrNoListening     = errors.New("task handler listens to no task types")
+	ErrUnhandledType   = errors.New("task type is unhandled")
+	ErrNilDecodeTarget = errors.New("task decode target is nil")
+	ErrPanic           = errors.New("task handler panicked")
+
+	// ErrSkipRetry marks a failure as non-retryable for provider adapters.
+	ErrSkipRetry = errors.New("skip retry for task")
+)

--- a/taskqueue/errors.go
+++ b/taskqueue/errors.go
@@ -3,12 +3,19 @@ package taskqueue
 import "errors"
 
 var (
-	ErrEmptyType       = errors.New("task type is empty")
-	ErrNilHandler      = errors.New("task handler is nil")
-	ErrNoListening     = errors.New("task handler listens to no task types")
-	ErrUnhandledType   = errors.New("task type is unhandled")
-	ErrNilDecodeTarget = errors.New("task decode target is nil")
-	ErrPanic           = errors.New("task handler panicked")
+	ErrEmptyType             = errors.New("task type is empty")
+	ErrNilProcessor          = errors.New("task processor is nil")
+	ErrUnhandledType         = errors.New("task type is unhandled")
+	ErrDuplicateProcessor    = errors.New("task processor is already registered")
+	ErrDuplicatePayloadType  = errors.New("task payload type is already registered")
+	ErrUnknownType           = errors.New("task type is unknown")
+	ErrUnknownPayloadType    = errors.New("task payload type is unknown")
+	ErrNilPayload            = errors.New("task payload is nil")
+	ErrNilDecodeTarget       = errors.New("task decode target is nil")
+	ErrNilPayloadFactory     = errors.New("task payload factory is nil or returned nil")
+	ErrInvalidPayloadFactory = errors.New("task payload factory returned invalid payload")
+	ErrNilPayloadResolver    = errors.New("task payload resolver is nil")
+	ErrPanic                 = errors.New("task processor panicked")
 
 	// ErrSkipRetry marks a failure as non-retryable for provider adapters.
 	ErrSkipRetry = errors.New("skip retry for task")

--- a/taskqueue/middleware.go
+++ b/taskqueue/middleware.go
@@ -1,0 +1,80 @@
+package taskqueue
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+)
+
+// Middleware wraps a task handler function.
+type Middleware func(HandlerFunc) HandlerFunc
+
+// Chain wraps handler with middleware in declaration order.
+func Chain(handler HandlerFunc, middleware ...Middleware) HandlerFunc {
+	for i := len(middleware) - 1; i >= 0; i-- {
+		if middleware[i] != nil {
+			handler = middleware[i](handler)
+		}
+	}
+	return handler
+}
+
+// Recover converts handler panics into ErrPanic.
+func Recover() Middleware {
+	return func(next HandlerFunc) HandlerFunc {
+		return func(ctx context.Context, task Task) (err error) {
+			if next == nil {
+				return ErrNilHandler
+			}
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					err = panicAsError(recovered)
+				}
+			}()
+			return next(ctx, task)
+		}
+	}
+}
+
+// Logging records task handler start, success, and failure events with slog.
+func Logging(logger *slog.Logger) Middleware {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return func(next HandlerFunc) HandlerFunc {
+		return func(ctx context.Context, task Task) error {
+			startedAt := time.Now()
+			attrs := []any{
+				"task_type", task.Type(),
+				"queue", task.Queue(),
+				"key", task.Key(),
+			}
+			logger.InfoContext(ctx, "taskqueue handler started", attrs...)
+
+			if next == nil {
+				return logTaskFailure(ctx, logger, attrs, startedAt, ErrNilHandler)
+			}
+			if err := next(ctx, task); err != nil {
+				return logTaskFailure(ctx, logger, attrs, startedAt, err)
+			}
+
+			logger.InfoContext(ctx, "taskqueue handler completed",
+				append(attrs, "elapsed", time.Since(startedAt).String())...)
+			return nil
+		}
+	}
+}
+
+func logTaskFailure(ctx context.Context, logger *slog.Logger, attrs []any, startedAt time.Time, err error) error {
+	logger.ErrorContext(ctx, "taskqueue handler failed",
+		append(attrs, "elapsed", time.Since(startedAt).String(), "error", err)...)
+	return err
+}
+
+func panicAsError(recovered any) error {
+	if err, ok := recovered.(error); ok {
+		return fmt.Errorf("%w: %w", ErrPanic, err)
+	}
+	return fmt.Errorf("%w: %v", ErrPanic, recovered)
+}

--- a/taskqueue/middleware.go
+++ b/taskqueue/middleware.go
@@ -7,25 +7,25 @@ import (
 	"time"
 )
 
-// Middleware wraps a task handler function.
-type Middleware func(HandlerFunc) HandlerFunc
+// Middleware wraps a task processor function.
+type Middleware func(ProcessorFunc) ProcessorFunc
 
-// Chain wraps handler with middleware in declaration order.
-func Chain(handler HandlerFunc, middleware ...Middleware) HandlerFunc {
+// Chain wraps processor with middleware in declaration order.
+func Chain(processor ProcessorFunc, middleware ...Middleware) ProcessorFunc {
 	for i := len(middleware) - 1; i >= 0; i-- {
 		if middleware[i] != nil {
-			handler = middleware[i](handler)
+			processor = middleware[i](processor)
 		}
 	}
-	return handler
+	return processor
 }
 
-// Recover converts handler panics into ErrPanic.
+// Recover converts processor panics into ErrPanic.
 func Recover() Middleware {
-	return func(next HandlerFunc) HandlerFunc {
+	return func(next ProcessorFunc) ProcessorFunc {
 		return func(ctx context.Context, task Task) (err error) {
 			if next == nil {
-				return ErrNilHandler
+				return ErrNilProcessor
 			}
 			defer func() {
 				if recovered := recover(); recovered != nil {
@@ -37,12 +37,12 @@ func Recover() Middleware {
 	}
 }
 
-// Logging records task handler start, success, and failure events with slog.
+// Logging records task processor start, success, and failure events with slog.
 func Logging(logger *slog.Logger) Middleware {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return func(next HandlerFunc) HandlerFunc {
+	return func(next ProcessorFunc) ProcessorFunc {
 		return func(ctx context.Context, task Task) error {
 			startedAt := time.Now()
 			attrs := []any{
@@ -50,16 +50,16 @@ func Logging(logger *slog.Logger) Middleware {
 				"queue", task.Queue(),
 				"key", task.Key(),
 			}
-			logger.InfoContext(ctx, "taskqueue handler started", attrs...)
+			logger.InfoContext(ctx, "taskqueue processor started", attrs...)
 
 			if next == nil {
-				return logTaskFailure(ctx, logger, attrs, startedAt, ErrNilHandler)
+				return logTaskFailure(ctx, logger, attrs, startedAt, ErrNilProcessor)
 			}
 			if err := next(ctx, task); err != nil {
 				return logTaskFailure(ctx, logger, attrs, startedAt, err)
 			}
 
-			logger.InfoContext(ctx, "taskqueue handler completed",
+			logger.InfoContext(ctx, "taskqueue processor completed",
 				append(attrs, "elapsed", time.Since(startedAt).String())...)
 			return nil
 		}
@@ -67,7 +67,7 @@ func Logging(logger *slog.Logger) Middleware {
 }
 
 func logTaskFailure(ctx context.Context, logger *slog.Logger, attrs []any, startedAt time.Time, err error) error {
-	logger.ErrorContext(ctx, "taskqueue handler failed",
+	logger.ErrorContext(ctx, "taskqueue processor failed",
 		append(attrs, "elapsed", time.Since(startedAt).String(), "error", err)...)
 	return err
 }

--- a/taskqueue/option.go
+++ b/taskqueue/option.go
@@ -1,0 +1,41 @@
+package taskqueue
+
+// Option configures task metadata.
+type Option func(*taskConfig)
+
+type taskConfig struct {
+	key     string
+	headers map[string]string
+}
+
+// WithKey sets the task idempotency or ordering key.
+func WithKey(key string) Option {
+	return func(cfg *taskConfig) {
+		cfg.key = key
+	}
+}
+
+// WithHeader adds one task metadata header.
+func WithHeader(key, value string) Option {
+	return func(cfg *taskConfig) {
+		if cfg.headers == nil {
+			cfg.headers = make(map[string]string)
+		}
+		cfg.headers[key] = value
+	}
+}
+
+// WithHeaders adds task metadata headers.
+func WithHeaders(headers map[string]string) Option {
+	return func(cfg *taskConfig) {
+		if len(headers) == 0 {
+			return
+		}
+		if cfg.headers == nil {
+			cfg.headers = make(map[string]string, len(headers))
+		}
+		for key, value := range headers {
+			cfg.headers[key] = value
+		}
+	}
+}

--- a/taskqueue/router.go
+++ b/taskqueue/router.go
@@ -1,0 +1,110 @@
+package taskqueue
+
+import (
+	"context"
+	"sync"
+)
+
+// Handler processes tasks for the types returned by Listening.
+type Handler interface {
+	Listening() []string
+	Handle(context.Context, Task) error
+}
+
+// HandlerFunc adapts a function to task handling middleware.
+type HandlerFunc func(context.Context, Task) error
+
+// Subscriber registers task handlers.
+//
+// Subscribe is a handler registration operation only. It does not imply that a
+// provider worker has started polling, acknowledged tasks, scheduled retries,
+// or joined a runtime process.
+type Subscriber interface {
+	Subscribe(Handler) error
+}
+
+// Runner is an optional runtime loop capability for providers that actively
+// consume tasks.
+type Runner interface {
+	Run(context.Context) error
+}
+
+type functionHandler struct {
+	fn    HandlerFunc
+	types []string
+}
+
+// NewHandlerFunc constructs a Handler from fn and listened task types.
+func NewHandlerFunc(fn HandlerFunc, types ...string) Handler {
+	return functionHandler{fn: fn, types: append([]string(nil), types...)}
+}
+
+func (h functionHandler) Listening() []string {
+	return append([]string(nil), h.types...)
+}
+
+func (h functionHandler) Handle(ctx context.Context, task Task) error {
+	if h.fn == nil {
+		return ErrNilHandler
+	}
+	return h.fn(ctx, task)
+}
+
+// Router registers handlers by task type and dispatches tasks sequentially.
+type Router struct {
+	mu       sync.RWMutex
+	handlers map[string][]Handler
+}
+
+var _ Subscriber = (*Router)(nil)
+
+// NewRouter constructs an empty task router.
+func NewRouter() *Router {
+	return &Router{handlers: make(map[string][]Handler)}
+}
+
+// Subscribe registers handler for each non-empty task type returned by Listening.
+func (r *Router) Subscribe(handler Handler) error {
+	if handler == nil {
+		return ErrNilHandler
+	}
+	types := handler.Listening()
+	if len(types) == 0 {
+		return ErrNoListening
+	}
+	seen := make(map[string]struct{}, len(types))
+	deduped := make([]string, 0, len(types))
+	for _, taskType := range types {
+		if taskType == "" {
+			return ErrEmptyType
+		}
+		if _, ok := seen[taskType]; ok {
+			continue
+		}
+		seen[taskType] = struct{}{}
+		deduped = append(deduped, taskType)
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for _, taskType := range deduped {
+		r.handlers[taskType] = append(r.handlers[taskType], handler)
+	}
+	return nil
+}
+
+// Handle dispatches task to all handlers registered for task.Type().
+func (r *Router) Handle(ctx context.Context, task Task) error {
+	r.mu.RLock()
+	handlers := append([]Handler(nil), r.handlers[task.Type()]...)
+	r.mu.RUnlock()
+	if len(handlers) == 0 {
+		return ErrUnhandledType
+	}
+	for _, handler := range handlers {
+		if err := handler.Handle(ctx, task); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/taskqueue/router.go
+++ b/taskqueue/router.go
@@ -5,22 +5,22 @@ import (
 	"sync"
 )
 
-// Handler processes tasks for the types returned by Listening.
-type Handler interface {
-	Listening() []string
-	Handle(context.Context, Task) error
+// Processor processes one task type.
+type Processor interface {
+	TaskType() TaskType
+	Process(context.Context, Task) error
 }
 
-// HandlerFunc adapts a function to task handling middleware.
-type HandlerFunc func(context.Context, Task) error
+// ProcessorFunc adapts a function to task processing middleware.
+type ProcessorFunc func(context.Context, Task) error
 
-// Subscriber registers task handlers.
+// Registrar registers task processors.
 //
-// Subscribe is a handler registration operation only. It does not imply that a
+// Register is a processor registration operation only. It does not imply that a
 // provider worker has started polling, acknowledged tasks, scheduled retries,
 // or joined a runtime process.
-type Subscriber interface {
-	Subscribe(Handler) error
+type Registrar interface {
+	Register(Processor) error
 }
 
 // Runner is an optional runtime loop capability for providers that actively
@@ -29,82 +29,66 @@ type Runner interface {
 	Run(context.Context) error
 }
 
-type functionHandler struct {
-	fn    HandlerFunc
-	types []string
+type functionProcessor struct {
+	taskType TaskType
+	fn       ProcessorFunc
 }
 
-// NewHandlerFunc constructs a Handler from fn and listened task types.
-func NewHandlerFunc(fn HandlerFunc, types ...string) Handler {
-	return functionHandler{fn: fn, types: append([]string(nil), types...)}
+// NewProcessor constructs a Processor for one task type.
+func NewProcessor(taskType TaskType, fn ProcessorFunc) Processor {
+	return functionProcessor{taskType: taskType, fn: fn}
 }
 
-func (h functionHandler) Listening() []string {
-	return append([]string(nil), h.types...)
+func (p functionProcessor) TaskType() TaskType {
+	return p.taskType
 }
 
-func (h functionHandler) Handle(ctx context.Context, task Task) error {
-	if h.fn == nil {
-		return ErrNilHandler
+func (p functionProcessor) Process(ctx context.Context, task Task) error {
+	if p.fn == nil {
+		return ErrNilProcessor
 	}
-	return h.fn(ctx, task)
+	return p.fn(ctx, task)
 }
 
-// Router registers handlers by task type and dispatches tasks sequentially.
+// Router registers processors by task type and dispatches tasks.
 type Router struct {
-	mu       sync.RWMutex
-	handlers map[string][]Handler
+	mu         sync.RWMutex
+	processors map[TaskType]Processor
 }
 
-var _ Subscriber = (*Router)(nil)
+var _ Registrar = (*Router)(nil)
 
 // NewRouter constructs an empty task router.
 func NewRouter() *Router {
-	return &Router{handlers: make(map[string][]Handler)}
+	return &Router{processors: make(map[TaskType]Processor)}
 }
 
-// Subscribe registers handler for each non-empty task type returned by Listening.
-func (r *Router) Subscribe(handler Handler) error {
-	if handler == nil {
-		return ErrNilHandler
+// Register registers one processor for its non-empty task type.
+func (r *Router) Register(processor Processor) error {
+	if processor == nil {
+		return ErrNilProcessor
 	}
-	types := handler.Listening()
-	if len(types) == 0 {
-		return ErrNoListening
-	}
-	seen := make(map[string]struct{}, len(types))
-	deduped := make([]string, 0, len(types))
-	for _, taskType := range types {
-		if taskType == "" {
-			return ErrEmptyType
-		}
-		if _, ok := seen[taskType]; ok {
-			continue
-		}
-		seen[taskType] = struct{}{}
-		deduped = append(deduped, taskType)
+	taskType := processor.TaskType()
+	if taskType == "" {
+		return ErrEmptyType
 	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	for _, taskType := range deduped {
-		r.handlers[taskType] = append(r.handlers[taskType], handler)
+	if _, ok := r.processors[taskType]; ok {
+		return ErrDuplicateProcessor
 	}
+	r.processors[taskType] = processor
 	return nil
 }
 
-// Handle dispatches task to all handlers registered for task.Type().
-func (r *Router) Handle(ctx context.Context, task Task) error {
+// Process dispatches task to the processor registered for task.Type().
+func (r *Router) Process(ctx context.Context, task Task) error {
 	r.mu.RLock()
-	handlers := append([]Handler(nil), r.handlers[task.Type()]...)
+	processor := r.processors[task.Type()]
 	r.mu.RUnlock()
-	if len(handlers) == 0 {
+	if processor == nil {
 		return ErrUnhandledType
 	}
-	for _, handler := range handlers {
-		if err := handler.Handle(ctx, task); err != nil {
-			return err
-		}
-	}
-	return nil
+	return processor.Process(ctx, task)
 }

--- a/taskqueue/schema.go
+++ b/taskqueue/schema.go
@@ -1,0 +1,180 @@
+package taskqueue
+
+import (
+	"reflect"
+	"sync"
+)
+
+// PayloadResolver allocates an empty JSON payload target for a task type.
+type PayloadResolver interface {
+	Resolve(TaskType) (any, error)
+}
+
+// PayloadResolverFunc adapts a function into a PayloadResolver.
+type PayloadResolverFunc func(TaskType) (any, error)
+
+// Resolve calls f(taskType).
+func (f PayloadResolverFunc) Resolve(taskType TaskType) (any, error) {
+	if f == nil {
+		return nil, ErrNilPayloadResolver
+	}
+	payload, err := f(taskType)
+	if err != nil {
+		return nil, err
+	}
+	if err := validatePayloadTarget(payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+type schemaEntry struct {
+	def         Definition
+	factory     func() any
+	payloadType reflect.Type
+}
+
+// SchemaRegistry maps semantic task types to Go payload schemas.
+type SchemaRegistry struct {
+	mu           sync.RWMutex
+	byType       map[TaskType]schemaEntry
+	byPayloadTyp map[reflect.Type]Definition
+}
+
+// NewSchemaRegistry creates an empty schema registry.
+func NewSchemaRegistry() *SchemaRegistry {
+	return &SchemaRegistry{
+		byType:       make(map[TaskType]schemaEntry),
+		byPayloadTyp: make(map[reflect.Type]Definition),
+	}
+}
+
+// Register associates a task definition with a factory for its JSON payload.
+func (r *SchemaRegistry) Register(def Definition, factory func() any) error {
+	if def.Type == "" {
+		return ErrEmptyType
+	}
+	if factory == nil {
+		return ErrNilPayloadFactory
+	}
+
+	payload := factory()
+	if err := validatePayloadTarget(payload); err != nil {
+		return err
+	}
+	payloadType, err := payloadSchemaType(payload)
+	if err != nil {
+		return err
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if existing, ok := r.byPayloadTyp[payloadType]; ok && existing.Type != def.Type {
+		return ErrDuplicatePayloadType
+	}
+	if existing, ok := r.byType[def.Type]; ok {
+		delete(r.byPayloadTyp, existing.payloadType)
+	}
+	r.byType[def.Type] = schemaEntry{
+		def:         def,
+		factory:     factory,
+		payloadType: payloadType,
+	}
+	r.byPayloadTyp[payloadType] = def
+	return nil
+}
+
+// Resolve returns a fresh JSON payload target for taskType.
+func (r *SchemaRegistry) Resolve(taskType TaskType) (any, error) {
+	r.mu.RLock()
+	entry, ok := r.byType[taskType]
+	r.mu.RUnlock()
+	if !ok {
+		return nil, ErrUnknownType
+	}
+
+	payload := entry.factory()
+	if err := validatePayloadTarget(payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+// DefinitionOf returns the task definition registered for payload's Go type.
+func (r *SchemaRegistry) DefinitionOf(payload any) (Definition, error) {
+	payloadType, err := payloadValueType(payload)
+	if err != nil {
+		return Definition{}, err
+	}
+
+	r.mu.RLock()
+	def, ok := r.byPayloadTyp[payloadType]
+	r.mu.RUnlock()
+	if !ok {
+		return Definition{}, ErrUnknownPayloadType
+	}
+	return def, nil
+}
+
+// NewJSONTask creates a JSON task using the definition registered for payload.
+func (r *SchemaRegistry) NewJSONTask(payload any, opts ...Option) (Task, error) {
+	def, err := r.DefinitionOf(payload)
+	if err != nil {
+		return Task{}, err
+	}
+	return NewJSONTask(def, payload, opts...)
+}
+
+// DecodeJSON resolves task.Type() and decodes task payload into that schema.
+func (r *SchemaRegistry) DecodeJSON(task Task) (any, error) {
+	payload, err := r.Resolve(task.Type())
+	if err != nil {
+		return nil, err
+	}
+	if err := DecodeJSON(task, payload); err != nil {
+		return nil, err
+	}
+	return payload, nil
+}
+
+func validatePayloadTarget(payload any) error {
+	if isNil(payload) {
+		return ErrNilPayloadFactory
+	}
+	if reflect.TypeOf(payload).Kind() != reflect.Pointer {
+		return ErrInvalidPayloadFactory
+	}
+	return nil
+}
+
+func payloadSchemaType(payload any) (reflect.Type, error) {
+	if err := validatePayloadTarget(payload); err != nil {
+		return nil, err
+	}
+	return reflect.TypeOf(payload).Elem(), nil
+}
+
+func payloadValueType(payload any) (reflect.Type, error) {
+	if isNil(payload) {
+		return nil, ErrNilPayload
+	}
+	payloadType := reflect.TypeOf(payload)
+	if payloadType.Kind() == reflect.Pointer {
+		payloadType = payloadType.Elem()
+	}
+	return payloadType, nil
+}
+
+func isNil(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return reflected.IsNil()
+	default:
+		return false
+	}
+}

--- a/taskqueue/schema_test.go
+++ b/taskqueue/schema_test.go
@@ -1,0 +1,151 @@
+package taskqueue
+
+import (
+	"errors"
+	"testing"
+)
+
+type reviewTaskPayload struct {
+	ID    string `json:"id"`
+	Limit int    `json:"limit"`
+}
+
+// Schema registry decode should allocate a fresh Go payload target for each
+// task type so provider adapters can deserialize tasks without hard-coded DTOs.
+func TestSchemaRegistry_DecodeJSONResolvesTaskPayload(t *testing.T) {
+	registry := NewSchemaRegistry()
+	def := Definition{Type: "document.review.v1", Queue: "reconcile"}
+	if err := registry.Register(def, func() any { return &reviewTaskPayload{} }); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+	task, err := NewJSONTask(def, reviewTaskPayload{ID: "doc-1", Limit: 10})
+	if err != nil {
+		t.Fatalf("NewJSONTask: %v", err)
+	}
+
+	decoded, err := registry.DecodeJSON(task)
+	if err != nil {
+		t.Fatalf("DecodeJSON: %v", err)
+	}
+	payload, ok := decoded.(*reviewTaskPayload)
+	if !ok {
+		t.Fatalf("decoded type = %T", decoded)
+	}
+	if payload.ID != "doc-1" || payload.Limit != 10 {
+		t.Fatalf("decoded payload = %#v", payload)
+	}
+
+	second, err := registry.Resolve(task.Type())
+	if err != nil {
+		t.Fatalf("resolve second: %v", err)
+	}
+	if second == decoded {
+		t.Fatal("Resolve returned shared payload target")
+	}
+}
+
+// Schema registry encode should derive task definition from a registered Go
+// payload type so application code does not duplicate task type strings.
+func TestSchemaRegistry_NewJSONTaskInfersDefinitionFromPayload(t *testing.T) {
+	registry := NewSchemaRegistry()
+	def := Definition{Type: "document.review.v1", Queue: "reconcile"}
+	if err := registry.Register(def, func() any { return &reviewTaskPayload{} }); err != nil {
+		t.Fatalf("register: %v", err)
+	}
+
+	task, err := registry.NewJSONTask(&reviewTaskPayload{ID: "doc-1"}, WithKey("doc-1"))
+	if err != nil {
+		t.Fatalf("NewJSONTask: %v", err)
+	}
+
+	if task.Type() != def.Type {
+		t.Fatalf("type = %q", task.Type())
+	}
+	if task.Queue() != def.Queue {
+		t.Fatalf("queue = %q", task.Queue())
+	}
+	if task.Key() != "doc-1" {
+		t.Fatalf("key = %q", task.Key())
+	}
+	if string(task.Payload()) != `{"id":"doc-1","limit":0}` {
+		t.Fatalf("payload = %s", task.Payload())
+	}
+}
+
+// Schema registry registration should reject invalid schemas near application
+// startup rather than failing later inside task workers.
+func TestSchemaRegistry_RejectsInvalidRegistration(t *testing.T) {
+	registry := NewSchemaRegistry()
+
+	if err := registry.Register(Definition{}, func() any { return &reviewTaskPayload{} }); !errors.Is(err, ErrEmptyType) {
+		t.Fatalf("empty type error = %v", err)
+	}
+	if err := registry.Register(Definition{Type: "document.review.v1"}, nil); !errors.Is(err, ErrNilPayloadFactory) {
+		t.Fatalf("nil factory error = %v", err)
+	}
+	if err := registry.Register(Definition{Type: "document.review.v1"}, func() any { return nil }); !errors.Is(err, ErrNilPayloadFactory) {
+		t.Fatalf("nil factory output error = %v", err)
+	}
+	if err := registry.Register(Definition{Type: "document.review.v1"}, func() any { return reviewTaskPayload{} }); !errors.Is(err, ErrInvalidPayloadFactory) {
+		t.Fatalf("non-pointer factory output error = %v", err)
+	}
+}
+
+// Registering one Go payload type for two task types should fail because
+// payload-to-definition lookup would otherwise become ambiguous.
+func TestSchemaRegistry_RejectsDuplicatePayloadType(t *testing.T) {
+	registry := NewSchemaRegistry()
+	if err := registry.Register(Definition{Type: "document.review.v1"}, func() any { return &reviewTaskPayload{} }); err != nil {
+		t.Fatalf("register first: %v", err)
+	}
+
+	err := registry.Register(Definition{Type: "document.retry_review.v1"}, func() any { return &reviewTaskPayload{} })
+	if !errors.Is(err, ErrDuplicatePayloadType) {
+		t.Fatalf("duplicate payload type error = %v, want ErrDuplicatePayloadType", err)
+	}
+}
+
+// Unknown task or payload types should fail clearly because adapters and
+// application code cannot infer a safe schema.
+func TestSchemaRegistry_RejectsUnknownSchemas(t *testing.T) {
+	registry := NewSchemaRegistry()
+
+	payload, err := registry.Resolve("missing.type")
+	if !errors.Is(err, ErrUnknownType) {
+		t.Fatalf("unknown type error = %v", err)
+	}
+	if payload != nil {
+		t.Fatalf("payload = %#v, want nil", payload)
+	}
+
+	if _, err := registry.DefinitionOf(reviewTaskPayload{}); !errors.Is(err, ErrUnknownPayloadType) {
+		t.Fatalf("unknown payload error = %v", err)
+	}
+	if _, err := registry.NewJSONTask(nil); !errors.Is(err, ErrNilPayload) {
+		t.Fatalf("nil payload error = %v", err)
+	}
+}
+
+// PayloadResolverFunc should enforce resolver contracts so adapters can treat
+// resolver output as a valid JSON decode target.
+func TestPayloadResolverFunc_RejectsNilAndInvalidOutputs(t *testing.T) {
+	var nilResolver PayloadResolverFunc
+	payload, err := nilResolver.Resolve("document.review.v1")
+	if !errors.Is(err, ErrNilPayloadResolver) {
+		t.Fatalf("nil resolver error = %v", err)
+	}
+	if payload != nil {
+		t.Fatalf("payload = %#v, want nil", payload)
+	}
+
+	invalidResolver := PayloadResolverFunc(func(TaskType) (any, error) {
+		return reviewTaskPayload{}, nil
+	})
+	payload, err = invalidResolver.Resolve("document.review.v1")
+	if !errors.Is(err, ErrInvalidPayloadFactory) {
+		t.Fatalf("invalid output error = %v", err)
+	}
+	if payload != nil {
+		t.Fatalf("payload = %#v, want nil", payload)
+	}
+}

--- a/taskqueue/task.go
+++ b/taskqueue/task.go
@@ -1,0 +1,106 @@
+package taskqueue
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Definition identifies a semantic task type and optional queue lane.
+type Definition struct {
+	Type  string
+	Queue string
+}
+
+// Task is a provider-neutral background task envelope.
+type Task struct {
+	def     Definition
+	payload []byte
+	key     string
+	headers map[string]string
+}
+
+// New constructs a task from raw payload bytes.
+func New(def Definition, payload []byte, opts ...Option) (Task, error) {
+	if def.Type == "" {
+		return Task{}, ErrEmptyType
+	}
+	cfg := taskConfig{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&cfg)
+		}
+	}
+	return Task{
+		def:     def,
+		payload: append([]byte(nil), payload...),
+		key:     cfg.key,
+		headers: cloneHeaders(cfg.headers),
+	}, nil
+}
+
+// NewJSONTask constructs a task by JSON-encoding payload.
+func NewJSONTask(def Definition, payload any, opts ...Option) (Task, error) {
+	if def.Type == "" {
+		return Task{}, ErrEmptyType
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return Task{}, fmt.Errorf("encode task payload: %w", err)
+	}
+	return New(def, data, opts...)
+}
+
+// DecodeJSON decodes a JSON task payload into target.
+func DecodeJSON(task Task, target any) error {
+	if target == nil {
+		return ErrNilDecodeTarget
+	}
+	if len(task.payload) == 0 {
+		return nil
+	}
+	if err := json.Unmarshal(task.payload, target); err != nil {
+		return fmt.Errorf("%w: %w", ErrSkipRetry, err)
+	}
+	return nil
+}
+
+// Type returns the semantic task contract type.
+func (t Task) Type() string {
+	return t.def.Type
+}
+
+// Queue returns the provider queue lane name.
+func (t Task) Queue() string {
+	return t.def.Queue
+}
+
+// Definition returns the task definition.
+func (t Task) Definition() Definition {
+	return t.def
+}
+
+// Payload returns a copy of the task payload bytes.
+func (t Task) Payload() []byte {
+	return append([]byte(nil), t.payload...)
+}
+
+// Key returns the task idempotency or ordering key.
+func (t Task) Key() string {
+	return t.key
+}
+
+// Headers returns a copy of task extension metadata.
+func (t Task) Headers() map[string]string {
+	return cloneHeaders(t.headers)
+}
+
+func cloneHeaders(headers map[string]string) map[string]string {
+	if len(headers) == 0 {
+		return nil
+	}
+	copied := make(map[string]string, len(headers))
+	for key, value := range headers {
+		copied[key] = value
+	}
+	return copied
+}

--- a/taskqueue/task.go
+++ b/taskqueue/task.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 )
 
+// TaskType is the semantic contract identifier for a task schema.
+type TaskType string
+
 // Definition identifies a semantic task type and optional queue lane.
 type Definition struct {
-	Type  string
+	Type  TaskType
 	Queue string
 }
 
@@ -65,7 +68,7 @@ func DecodeJSON(task Task, target any) error {
 }
 
 // Type returns the semantic task contract type.
-func (t Task) Type() string {
+func (t Task) Type() TaskType {
 	return t.def.Type
 }
 

--- a/taskqueue/task_test.go
+++ b/taskqueue/task_test.go
@@ -1,0 +1,288 @@
+package taskqueue
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// Empty task types must be rejected so provider adapters never enqueue
+// tasks that no handler can safely route.
+func TestNewJSONTask_EmptyTypeReturnsError(t *testing.T) {
+	_, err := NewJSONTask(Definition{}, struct{}{})
+	if !errors.Is(err, ErrEmptyType) {
+		t.Fatalf("error = %v, want ErrEmptyType", err)
+	}
+}
+
+// Empty task type validation should run before payload encoding so callers get
+// a stable routing-contract error even when the payload is invalid.
+func TestNewJSONTask_EmptyTypeReturnsErrorBeforeEncodingPayload(t *testing.T) {
+	_, err := NewJSONTask(Definition{}, func() {})
+	if !errors.Is(err, ErrEmptyType) {
+		t.Fatalf("error = %v, want ErrEmptyType", err)
+	}
+}
+
+// JSON task construction should preserve the transport-neutral definition,
+// key, and headers while copying mutable metadata away from caller state.
+func TestNewJSONTask_PreservesDefinitionAndCopiesHeaders(t *testing.T) {
+	headers := map[string]string{"trace-id": "trace-1"}
+	task, err := NewJSONTask(Definition{Type: "document.review.v1", Queue: "reconcile"},
+		struct {
+			ID string `json:"id"`
+		}{ID: "doc-1"},
+		WithKey("doc-1"),
+		WithHeader("source", "scheduler"),
+		WithHeaders(headers),
+	)
+	if err != nil {
+		t.Fatalf("NewJSONTask: %v", err)
+	}
+	headers["trace-id"] = "mutated"
+
+	if task.Type() != "document.review.v1" {
+		t.Fatalf("type = %q", task.Type())
+	}
+	if task.Queue() != "reconcile" {
+		t.Fatalf("queue = %q", task.Queue())
+	}
+	if task.Key() != "doc-1" {
+		t.Fatalf("key = %q", task.Key())
+	}
+	if got := task.Headers(); !reflect.DeepEqual(got, map[string]string{"source": "scheduler", "trace-id": "trace-1"}) {
+		t.Fatalf("headers = %#v", got)
+	}
+	if string(task.Payload()) != `{"id":"doc-1"}` {
+		t.Fatalf("payload = %s", task.Payload())
+	}
+}
+
+// DecodeJSON should decode the task payload into the caller-owned target and
+// fail loudly for nil targets so bad adapters cannot silently drop payloads.
+func TestDecodeJSON_DecodesPayloadAndRejectsNilTarget(t *testing.T) {
+	task, err := NewJSONTask(Definition{Type: "document.review.v1"}, struct {
+		Limit int `json:"limit"`
+	}{Limit: 25})
+	if err != nil {
+		t.Fatalf("NewJSONTask: %v", err)
+	}
+
+	var payload struct {
+		Limit int `json:"limit"`
+	}
+	if err := DecodeJSON(task, &payload); err != nil {
+		t.Fatalf("DecodeJSON: %v", err)
+	}
+	if payload.Limit != 25 {
+		t.Fatalf("limit = %d", payload.Limit)
+	}
+	if err := DecodeJSON(task, nil); !errors.Is(err, ErrNilDecodeTarget) {
+		t.Fatalf("nil target error = %v, want ErrNilDecodeTarget", err)
+	}
+}
+
+// Router dispatch should call every matching handler in registration order
+// and stop before later handlers when one handler fails.
+func TestRouter_HandleDispatchesInOrderAndStopsOnError(t *testing.T) {
+	router := NewRouter()
+	var calls []string
+	if err := router.Subscribe(NewHandlerFunc(func(context.Context, Task) error {
+		calls = append(calls, "first")
+		return nil
+	}, "document.review.v1")); err != nil {
+		t.Fatalf("subscribe first: %v", err)
+	}
+	wantErr := errors.New("stop")
+	if err := router.Subscribe(NewHandlerFunc(func(context.Context, Task) error {
+		calls = append(calls, "second")
+		return wantErr
+	}, "document.review.v1")); err != nil {
+		t.Fatalf("subscribe second: %v", err)
+	}
+	if err := router.Subscribe(NewHandlerFunc(func(context.Context, Task) error {
+		calls = append(calls, "third")
+		return nil
+	}, "document.review.v1")); err != nil {
+		t.Fatalf("subscribe third: %v", err)
+	}
+
+	task, err := NewJSONTask(Definition{Type: "document.review.v1"}, struct{}{})
+	if err != nil {
+		t.Fatalf("NewJSONTask: %v", err)
+	}
+	err = router.Handle(context.Background(), task)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("handle error = %v, want %v", err, wantErr)
+	}
+	if !reflect.DeepEqual(calls, []string{"first", "second"}) {
+		t.Fatalf("calls = %#v", calls)
+	}
+}
+
+// Router registration and dispatch should surface stable errors for invalid
+// handlers and unhandled task types.
+func TestRouter_ValidationErrors(t *testing.T) {
+	router := NewRouter()
+	if err := router.Subscribe(nil); !errors.Is(err, ErrNilHandler) {
+		t.Fatalf("nil handler error = %v", err)
+	}
+	if err := router.Subscribe(NewHandlerFunc(func(context.Context, Task) error { return nil })); !errors.Is(err, ErrNoListening) {
+		t.Fatalf("no listening error = %v", err)
+	}
+	if err := router.Subscribe(NewHandlerFunc(func(context.Context, Task) error { return nil }, "")); !errors.Is(err, ErrEmptyType) {
+		t.Fatalf("empty type error = %v", err)
+	}
+
+	task, err := NewJSONTask(Definition{Type: "unhandled"}, struct{}{})
+	if err != nil {
+		t.Fatalf("NewJSONTask: %v", err)
+	}
+	if err := router.Handle(context.Background(), task); !errors.Is(err, ErrUnhandledType) {
+		t.Fatalf("unhandled error = %v", err)
+	}
+}
+
+// Router should be usable through the Subscriber capability so provider
+// adapters and modules can register handlers without depending on Router.
+func TestRouter_SubscribeThroughSubscriberInterface(t *testing.T) {
+	router := NewRouter()
+	var subscriber Subscriber = router
+	called := false
+
+	if err := subscriber.Subscribe(NewHandlerFunc(func(context.Context, Task) error {
+		called = true
+		return nil
+	}, "document.review.v1")); err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	task, err := NewJSONTask(Definition{Type: "document.review.v1"}, struct{}{})
+	if err != nil {
+		t.Fatalf("NewJSONTask: %v", err)
+	}
+	if err := router.Handle(context.Background(), task); err != nil {
+		t.Fatalf("handle: %v", err)
+	}
+	if !called {
+		t.Fatal("handler was not called")
+	}
+}
+
+// Middleware should wrap in declaration order so shared logging/recovery
+// behavior can surround business handlers consistently.
+func TestChain_WrapsInDeclarationOrder(t *testing.T) {
+	var calls []string
+	mw := func(name string) Middleware {
+		return func(next HandlerFunc) HandlerFunc {
+			return func(ctx context.Context, task Task) error {
+				calls = append(calls, name+":before")
+				err := next(ctx, task)
+				calls = append(calls, name+":after")
+				return err
+			}
+		}
+	}
+	handler := Chain(func(context.Context, Task) error {
+		calls = append(calls, "handler")
+		return nil
+	}, mw("outer"), mw("inner"))
+
+	task, err := NewJSONTask(Definition{Type: "document.review.v1"}, struct{}{})
+	if err != nil {
+		t.Fatalf("NewJSONTask: %v", err)
+	}
+	if err := handler(context.Background(), task); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+	want := []string{"outer:before", "inner:before", "handler", "inner:after", "outer:after"}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %#v, want %#v", calls, want)
+	}
+}
+
+// Recover should convert handler panics into a stable error so worker
+// processes can report task failure without crashing.
+func TestRecover_ConvertsPanicToError(t *testing.T) {
+	handler := Chain(func(context.Context, Task) error {
+		panic("handler crashed")
+	}, Recover())
+
+	task, err := NewJSONTask(Definition{Type: "document.review.v1"}, struct{}{})
+	if err != nil {
+		t.Fatalf("NewJSONTask: %v", err)
+	}
+	err = handler(context.Background(), task)
+	if !errors.Is(err, ErrPanic) {
+		t.Fatalf("handler error = %v, want ErrPanic", err)
+	}
+	if !strings.Contains(err.Error(), "handler crashed") {
+		t.Fatalf("handler error = %q, want panic detail", err)
+	}
+}
+
+// Logging should emit task identity and outcome fields around a successful
+// handler call so operators can trace background task execution.
+func TestLogging_RecordsSuccessfulTask(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
+	handler := Chain(func(context.Context, Task) error {
+		return nil
+	}, Logging(logger))
+
+	task, err := NewJSONTask(Definition{Type: "document.review.v1", Queue: "reconcile"}, struct{}{}, WithKey("doc-1"))
+	if err != nil {
+		t.Fatalf("NewJSONTask: %v", err)
+	}
+	if err := handler(context.Background(), task); err != nil {
+		t.Fatalf("handler: %v", err)
+	}
+
+	output := logs.String()
+	for _, want := range []string{
+		`"msg":"taskqueue handler started"`,
+		`"msg":"taskqueue handler completed"`,
+		`"task_type":"document.review.v1"`,
+		`"queue":"reconcile"`,
+		`"key":"doc-1"`,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("logs = %s, want %s", output, want)
+		}
+	}
+}
+
+// Logging should preserve the handler error while recording failure fields
+// so retry decisions stay unchanged and failures remain observable.
+func TestLogging_RecordsFailedTask(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
+	wantErr := errors.New("retry later")
+	handler := Chain(func(context.Context, Task) error {
+		return wantErr
+	}, Logging(logger))
+
+	task, err := NewJSONTask(Definition{Type: "document.review.v1"}, struct{}{})
+	if err != nil {
+		t.Fatalf("NewJSONTask: %v", err)
+	}
+	err = handler(context.Background(), task)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("handler error = %v, want %v", err, wantErr)
+	}
+
+	output := logs.String()
+	for _, want := range []string{
+		`"msg":"taskqueue handler failed"`,
+		`"task_type":"document.review.v1"`,
+		`"error":"retry later"`,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("logs = %s, want %s", output, want)
+		}
+	}
+}

--- a/taskqueue/task_test.go
+++ b/taskqueue/task_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 )
 
-// Empty task types must be rejected so provider adapters never enqueue
-// tasks that no handler can safely route.
+// Empty task types must be rejected so provider adapters never enqueue tasks
+// that no processor can safely route.
 func TestNewJSONTask_EmptyTypeReturnsError(t *testing.T) {
 	_, err := NewJSONTask(Definition{}, struct{}{})
 	if !errors.Is(err, ErrEmptyType) {
@@ -45,7 +45,7 @@ func TestNewJSONTask_PreservesDefinitionAndCopiesHeaders(t *testing.T) {
 	}
 	headers["trace-id"] = "mutated"
 
-	if task.Type() != "document.review.v1" {
+	if task.Type() != TaskType("document.review.v1") {
 		t.Fatalf("type = %q", task.Type())
 	}
 	if task.Queue() != "reconcile" {
@@ -86,55 +86,52 @@ func TestDecodeJSON_DecodesPayloadAndRejectsNilTarget(t *testing.T) {
 	}
 }
 
-// Router dispatch should call every matching handler in registration order
-// and stop before later handlers when one handler fails.
-func TestRouter_HandleDispatchesInOrderAndStopsOnError(t *testing.T) {
+// Router dispatch should call the single processor registered for a task type
+// so task processing remains command-like rather than event fan-out.
+func TestRouter_ProcessDispatchesSingleProcessor(t *testing.T) {
 	router := NewRouter()
-	var calls []string
-	if err := router.Subscribe(NewHandlerFunc(func(context.Context, Task) error {
-		calls = append(calls, "first")
+	called := false
+	if err := router.Register(NewProcessor("document.review.v1", func(context.Context, Task) error {
+		called = true
 		return nil
-	}, "document.review.v1")); err != nil {
-		t.Fatalf("subscribe first: %v", err)
-	}
-	wantErr := errors.New("stop")
-	if err := router.Subscribe(NewHandlerFunc(func(context.Context, Task) error {
-		calls = append(calls, "second")
-		return wantErr
-	}, "document.review.v1")); err != nil {
-		t.Fatalf("subscribe second: %v", err)
-	}
-	if err := router.Subscribe(NewHandlerFunc(func(context.Context, Task) error {
-		calls = append(calls, "third")
-		return nil
-	}, "document.review.v1")); err != nil {
-		t.Fatalf("subscribe third: %v", err)
+	})); err != nil {
+		t.Fatalf("register: %v", err)
 	}
 
 	task, err := NewJSONTask(Definition{Type: "document.review.v1"}, struct{}{})
 	if err != nil {
 		t.Fatalf("NewJSONTask: %v", err)
 	}
-	err = router.Handle(context.Background(), task)
-	if !errors.Is(err, wantErr) {
-		t.Fatalf("handle error = %v, want %v", err, wantErr)
+	if err := router.Process(context.Background(), task); err != nil {
+		t.Fatalf("process: %v", err)
 	}
-	if !reflect.DeepEqual(calls, []string{"first", "second"}) {
-		t.Fatalf("calls = %#v", calls)
+	if !called {
+		t.Fatal("processor was not called")
+	}
+}
+
+// Router registration should reject duplicate processors for the same task
+// type so a task cannot be accidentally processed twice.
+func TestRouter_RegisterRejectsDuplicateProcessor(t *testing.T) {
+	router := NewRouter()
+	if err := router.Register(NewProcessor("document.review.v1", func(context.Context, Task) error { return nil })); err != nil {
+		t.Fatalf("register first: %v", err)
+	}
+
+	err := router.Register(NewProcessor("document.review.v1", func(context.Context, Task) error { return nil }))
+	if !errors.Is(err, ErrDuplicateProcessor) {
+		t.Fatalf("duplicate error = %v, want ErrDuplicateProcessor", err)
 	}
 }
 
 // Router registration and dispatch should surface stable errors for invalid
-// handlers and unhandled task types.
+// processors and unhandled task types.
 func TestRouter_ValidationErrors(t *testing.T) {
 	router := NewRouter()
-	if err := router.Subscribe(nil); !errors.Is(err, ErrNilHandler) {
-		t.Fatalf("nil handler error = %v", err)
+	if err := router.Register(nil); !errors.Is(err, ErrNilProcessor) {
+		t.Fatalf("nil processor error = %v", err)
 	}
-	if err := router.Subscribe(NewHandlerFunc(func(context.Context, Task) error { return nil })); !errors.Is(err, ErrNoListening) {
-		t.Fatalf("no listening error = %v", err)
-	}
-	if err := router.Subscribe(NewHandlerFunc(func(context.Context, Task) error { return nil }, "")); !errors.Is(err, ErrEmptyType) {
+	if err := router.Register(NewProcessor("", func(context.Context, Task) error { return nil })); !errors.Is(err, ErrEmptyType) {
 		t.Fatalf("empty type error = %v", err)
 	}
 
@@ -142,43 +139,43 @@ func TestRouter_ValidationErrors(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJSONTask: %v", err)
 	}
-	if err := router.Handle(context.Background(), task); !errors.Is(err, ErrUnhandledType) {
+	if err := router.Process(context.Background(), task); !errors.Is(err, ErrUnhandledType) {
 		t.Fatalf("unhandled error = %v", err)
 	}
 }
 
-// Router should be usable through the Subscriber capability so provider
-// adapters and modules can register handlers without depending on Router.
-func TestRouter_SubscribeThroughSubscriberInterface(t *testing.T) {
+// Router should be usable through the Registrar capability so provider adapters
+// and modules can register processors without depending on Router.
+func TestRouter_RegisterThroughRegistrarInterface(t *testing.T) {
 	router := NewRouter()
-	var subscriber Subscriber = router
+	var registrar Registrar = router
 	called := false
 
-	if err := subscriber.Subscribe(NewHandlerFunc(func(context.Context, Task) error {
+	if err := registrar.Register(NewProcessor("document.review.v1", func(context.Context, Task) error {
 		called = true
 		return nil
-	}, "document.review.v1")); err != nil {
-		t.Fatalf("subscribe: %v", err)
+	})); err != nil {
+		t.Fatalf("register: %v", err)
 	}
 
 	task, err := NewJSONTask(Definition{Type: "document.review.v1"}, struct{}{})
 	if err != nil {
 		t.Fatalf("NewJSONTask: %v", err)
 	}
-	if err := router.Handle(context.Background(), task); err != nil {
-		t.Fatalf("handle: %v", err)
+	if err := router.Process(context.Background(), task); err != nil {
+		t.Fatalf("process: %v", err)
 	}
 	if !called {
-		t.Fatal("handler was not called")
+		t.Fatal("processor was not called")
 	}
 }
 
 // Middleware should wrap in declaration order so shared logging/recovery
-// behavior can surround business handlers consistently.
+// behavior can surround task processors consistently.
 func TestChain_WrapsInDeclarationOrder(t *testing.T) {
 	var calls []string
 	mw := func(name string) Middleware {
-		return func(next HandlerFunc) HandlerFunc {
+		return func(next ProcessorFunc) ProcessorFunc {
 			return func(ctx context.Context, task Task) error {
 				calls = append(calls, name+":before")
 				err := next(ctx, task)
@@ -187,8 +184,8 @@ func TestChain_WrapsInDeclarationOrder(t *testing.T) {
 			}
 		}
 	}
-	handler := Chain(func(context.Context, Task) error {
-		calls = append(calls, "handler")
+	processor := Chain(func(context.Context, Task) error {
+		calls = append(calls, "processor")
 		return nil
 	}, mw("outer"), mw("inner"))
 
@@ -196,41 +193,41 @@ func TestChain_WrapsInDeclarationOrder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJSONTask: %v", err)
 	}
-	if err := handler(context.Background(), task); err != nil {
-		t.Fatalf("handler: %v", err)
+	if err := processor(context.Background(), task); err != nil {
+		t.Fatalf("processor: %v", err)
 	}
-	want := []string{"outer:before", "inner:before", "handler", "inner:after", "outer:after"}
+	want := []string{"outer:before", "inner:before", "processor", "inner:after", "outer:after"}
 	if !reflect.DeepEqual(calls, want) {
 		t.Fatalf("calls = %#v, want %#v", calls, want)
 	}
 }
 
-// Recover should convert handler panics into a stable error so worker
+// Recover should convert processor panics into a stable error so worker
 // processes can report task failure without crashing.
 func TestRecover_ConvertsPanicToError(t *testing.T) {
-	handler := Chain(func(context.Context, Task) error {
-		panic("handler crashed")
+	processor := Chain(func(context.Context, Task) error {
+		panic("processor crashed")
 	}, Recover())
 
 	task, err := NewJSONTask(Definition{Type: "document.review.v1"}, struct{}{})
 	if err != nil {
 		t.Fatalf("NewJSONTask: %v", err)
 	}
-	err = handler(context.Background(), task)
+	err = processor(context.Background(), task)
 	if !errors.Is(err, ErrPanic) {
-		t.Fatalf("handler error = %v, want ErrPanic", err)
+		t.Fatalf("processor error = %v, want ErrPanic", err)
 	}
-	if !strings.Contains(err.Error(), "handler crashed") {
-		t.Fatalf("handler error = %q, want panic detail", err)
+	if !strings.Contains(err.Error(), "processor crashed") {
+		t.Fatalf("processor error = %q, want panic detail", err)
 	}
 }
 
 // Logging should emit task identity and outcome fields around a successful
-// handler call so operators can trace background task execution.
+// processor call so operators can trace background task execution.
 func TestLogging_RecordsSuccessfulTask(t *testing.T) {
 	var logs bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&logs, nil))
-	handler := Chain(func(context.Context, Task) error {
+	processor := Chain(func(context.Context, Task) error {
 		return nil
 	}, Logging(logger))
 
@@ -238,14 +235,14 @@ func TestLogging_RecordsSuccessfulTask(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJSONTask: %v", err)
 	}
-	if err := handler(context.Background(), task); err != nil {
-		t.Fatalf("handler: %v", err)
+	if err := processor(context.Background(), task); err != nil {
+		t.Fatalf("processor: %v", err)
 	}
 
 	output := logs.String()
 	for _, want := range []string{
-		`"msg":"taskqueue handler started"`,
-		`"msg":"taskqueue handler completed"`,
+		`"msg":"taskqueue processor started"`,
+		`"msg":"taskqueue processor completed"`,
 		`"task_type":"document.review.v1"`,
 		`"queue":"reconcile"`,
 		`"key":"doc-1"`,
@@ -256,13 +253,13 @@ func TestLogging_RecordsSuccessfulTask(t *testing.T) {
 	}
 }
 
-// Logging should preserve the handler error while recording failure fields
+// Logging should preserve the processor error while recording failure fields
 // so retry decisions stay unchanged and failures remain observable.
 func TestLogging_RecordsFailedTask(t *testing.T) {
 	var logs bytes.Buffer
 	logger := slog.New(slog.NewJSONHandler(&logs, nil))
 	wantErr := errors.New("retry later")
-	handler := Chain(func(context.Context, Task) error {
+	processor := Chain(func(context.Context, Task) error {
 		return wantErr
 	}, Logging(logger))
 
@@ -270,14 +267,14 @@ func TestLogging_RecordsFailedTask(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJSONTask: %v", err)
 	}
-	err = handler(context.Background(), task)
+	err = processor(context.Background(), task)
 	if !errors.Is(err, wantErr) {
-		t.Fatalf("handler error = %v, want %v", err, wantErr)
+		t.Fatalf("processor error = %v, want %v", err, wantErr)
 	}
 
 	output := logs.String()
 	for _, want := range []string{
-		`"msg":"taskqueue handler failed"`,
+		`"msg":"taskqueue processor failed"`,
 		`"task_type":"document.review.v1"`,
 		`"error":"retry later"`,
 	} {


### PR DESCRIPTION
## Summary
- add transport-neutral `taskqueue` task envelope, `TaskType`, JSON helpers, enqueue capability, and enqueue options
- add schema registry for `TaskType` <-> Go payload factory mapping, plus registry-based JSON task creation and decoding
- replace multi-type handler/listening API with single-task-type `Processor`, `Registrar`, `Router.Register`, and `Router.Process`
- add middleware chain, slog logging middleware, panic recovery, and stable taskqueue errors

## Verification
- `go test ./taskqueue`
- `go test ./...`

No `replace` directive or contrib wiring is included in this PR.