### PR TITLE
Enhance taskqueue runtime metadata

### DIFF
--- a/taskqueue/doc.go
+++ b/taskqueue/doc.go
@@ -1,13 +1,16 @@
 // Package taskqueue defines transport-neutral task queue contracts.
 //
 // It models background tasks as semantic Task values, plus provider-neutral
-// capabilities for enqueueing, handler registration, middleware, and runtime
-// loops. It intentionally does not define worker storage, acknowledgement,
-// retry, dead-letter, cron, or locking behavior. Provider adapters map these
-// contracts to their own queue systems.
+// capabilities for enqueueing, handler registration, middleware, worker
+// lifecycle, and runtime loops. It intentionally does not define worker
+// storage, acknowledgement, retry, dead-letter, cron, or locking behavior.
+// Provider adapters map these contracts to their own queue systems.
 //
 // TaskType is a semantic contract identifier used for schema and processor
 // routing. Queue is an optional provider-facing lane name. Providers decide how
 // to encode TaskType, Queue, Key, Headers, payload bytes, and enqueue options
 // into their own envelopes.
+//
+// ExecutionInfo carries provider worker metadata for the current processing
+// attempt through context; it does not change the task payload schema.
 package taskqueue

--- a/taskqueue/execution.go
+++ b/taskqueue/execution.go
@@ -1,0 +1,94 @@
+package taskqueue
+
+import "context"
+
+type executionInfoContextKey struct{}
+
+// ExecutionInfo carries provider worker metadata for the current processing
+// attempt. It is not part of the task payload schema.
+type ExecutionInfo struct {
+	taskID        string
+	queue         string
+	retryCount    int
+	retryCountSet bool
+	maxRetry      int
+	maxRetrySet   bool
+}
+
+// ExecutionInfoOption configures execution metadata.
+type ExecutionInfoOption func(*ExecutionInfo)
+
+// NewExecutionInfo applies opts and returns execution metadata.
+func NewExecutionInfo(opts ...ExecutionInfoOption) ExecutionInfo {
+	info := ExecutionInfo{}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(&info)
+		}
+	}
+	return info
+}
+
+// WithExecutionTaskID records the provider task identifier for this attempt.
+func WithExecutionTaskID(taskID string) ExecutionInfoOption {
+	return func(info *ExecutionInfo) {
+		info.taskID = taskID
+	}
+}
+
+// WithExecutionQueue records the provider queue lane for this attempt.
+func WithExecutionQueue(queue string) ExecutionInfoOption {
+	return func(info *ExecutionInfo) {
+		info.queue = queue
+	}
+}
+
+// WithExecutionRetryCount records how many prior attempts have failed.
+func WithExecutionRetryCount(retryCount int) ExecutionInfoOption {
+	return func(info *ExecutionInfo) {
+		info.retryCount = retryCount
+		info.retryCountSet = true
+	}
+}
+
+// WithExecutionMaxRetry records the provider retry cap for this task.
+func WithExecutionMaxRetry(maxRetry int) ExecutionInfoOption {
+	return func(info *ExecutionInfo) {
+		info.maxRetry = maxRetry
+		info.maxRetrySet = true
+	}
+}
+
+// TaskID returns the provider task identifier.
+func (i ExecutionInfo) TaskID() string {
+	return i.taskID
+}
+
+// Queue returns the provider queue lane.
+func (i ExecutionInfo) Queue() string {
+	return i.queue
+}
+
+// RetryCount returns the provider retry count and whether it was supplied.
+func (i ExecutionInfo) RetryCount() (int, bool) {
+	return i.retryCount, i.retryCountSet
+}
+
+// MaxRetry returns the provider retry cap and whether it was supplied.
+func (i ExecutionInfo) MaxRetry() (int, bool) {
+	return i.maxRetry, i.maxRetrySet
+}
+
+// ContextWithExecutionInfo stores execution metadata in ctx.
+func ContextWithExecutionInfo(ctx context.Context, info ExecutionInfo) context.Context {
+	return context.WithValue(ctx, executionInfoContextKey{}, info)
+}
+
+// ExecutionInfoFromContext returns execution metadata from ctx when present.
+func ExecutionInfoFromContext(ctx context.Context) (ExecutionInfo, bool) {
+	if ctx == nil {
+		return ExecutionInfo{}, false
+	}
+	info, ok := ctx.Value(executionInfoContextKey{}).(ExecutionInfo)
+	return info, ok
+}

--- a/taskqueue/execution_test.go
+++ b/taskqueue/execution_test.go
@@ -1,0 +1,64 @@
+package taskqueue
+
+import (
+	"context"
+	"testing"
+)
+
+// Execution info should travel through context so provider adapters can expose
+// worker metadata to processors without extending the task payload schema.
+func TestExecutionInfoContext_RoundTrip(t *testing.T) {
+	info := NewExecutionInfo(
+		WithExecutionTaskID("provider-task-1"),
+		WithExecutionQueue("reconcile"),
+		WithExecutionRetryCount(2),
+		WithExecutionMaxRetry(5),
+	)
+
+	ctx := ContextWithExecutionInfo(context.Background(), info)
+	got, ok := ExecutionInfoFromContext(ctx)
+	if !ok {
+		t.Fatal("ExecutionInfoFromContext did not find execution info")
+	}
+	if got.TaskID() != "provider-task-1" {
+		t.Fatalf("task id = %q", got.TaskID())
+	}
+	if got.Queue() != "reconcile" {
+		t.Fatalf("queue = %q", got.Queue())
+	}
+	retryCount, ok := got.RetryCount()
+	if !ok || retryCount != 2 {
+		t.Fatalf("retry count = %d, %t; want 2, true", retryCount, ok)
+	}
+	maxRetry, ok := got.MaxRetry()
+	if !ok || maxRetry != 5 {
+		t.Fatalf("max retry = %d, %t; want 5, true", maxRetry, ok)
+	}
+}
+
+// Missing execution info should be observable so processors can distinguish a
+// provider that lacks metadata from a real zero retry count.
+func TestExecutionInfoFromContext_Missing(t *testing.T) {
+	info, ok := ExecutionInfoFromContext(context.Background())
+	if ok {
+		t.Fatalf("found execution info = %#v, want missing", info)
+	}
+}
+
+// Explicit zero values should remain distinguishable from missing metadata
+// because first attempts commonly have retry count zero.
+func TestExecutionInfo_ReportsExplicitZeroRetryValues(t *testing.T) {
+	info := NewExecutionInfo(
+		WithExecutionRetryCount(0),
+		WithExecutionMaxRetry(0),
+	)
+
+	retryCount, ok := info.RetryCount()
+	if !ok || retryCount != 0 {
+		t.Fatalf("retry count = %d, %t; want 0, true", retryCount, ok)
+	}
+	maxRetry, ok := info.MaxRetry()
+	if !ok || maxRetry != 0 {
+		t.Fatalf("max retry = %d, %t; want 0, true", maxRetry, ok)
+	}
+}

--- a/taskqueue/middleware.go
+++ b/taskqueue/middleware.go
@@ -50,6 +50,7 @@ func Logging(logger *slog.Logger) Middleware {
 				"queue", task.Queue(),
 				"key", task.Key(),
 			}
+			attrs = appendExecutionInfoAttrs(ctx, attrs)
 			logger.InfoContext(ctx, "taskqueue processor started", attrs...)
 
 			if next == nil {
@@ -70,6 +71,26 @@ func logTaskFailure(ctx context.Context, logger *slog.Logger, attrs []any, start
 	logger.ErrorContext(ctx, "taskqueue processor failed",
 		append(attrs, "elapsed", time.Since(startedAt).String(), "error", err)...)
 	return err
+}
+
+func appendExecutionInfoAttrs(ctx context.Context, attrs []any) []any {
+	info, ok := ExecutionInfoFromContext(ctx)
+	if !ok {
+		return attrs
+	}
+	if info.TaskID() != "" {
+		attrs = append(attrs, "task_id", info.TaskID())
+	}
+	if info.Queue() != "" {
+		attrs = append(attrs, "execution_queue", info.Queue())
+	}
+	if retryCount, ok := info.RetryCount(); ok {
+		attrs = append(attrs, "retry_count", retryCount)
+	}
+	if maxRetry, ok := info.MaxRetry(); ok {
+		attrs = append(attrs, "max_retry", maxRetry)
+	}
+	return attrs
 }
 
 func panicAsError(recovered any) error {

--- a/taskqueue/router.go
+++ b/taskqueue/router.go
@@ -23,12 +23,6 @@ type Registrar interface {
 	Register(Processor) error
 }
 
-// Runner is an optional runtime loop capability for providers that actively
-// consume tasks.
-type Runner interface {
-	Run(context.Context) error
-}
-
 type functionProcessor struct {
 	taskType TaskType
 	fn       ProcessorFunc

--- a/taskqueue/runtime.go
+++ b/taskqueue/runtime.go
@@ -1,0 +1,25 @@
+package taskqueue
+
+import "context"
+
+// Runner is an optional runtime loop capability for providers that actively
+// consume tasks.
+//
+// Run should start consuming tasks and block until ctx is done or startup fails.
+// Context cancellation is a normal shutdown signal: implementations should stop
+// accepting new work, gracefully drain in-flight tasks when supported, and
+// return nil unless startup or shutdown itself fails.
+type Runner interface {
+	Run(context.Context) error
+}
+
+// Worker is an optional lifecycle capability for provider workers managed by
+// application runtime hooks.
+//
+// Start should begin accepting tasks and return after startup succeeds or
+// fails. Shutdown should stop accepting new tasks and wait for in-flight tasks
+// to finish until ctx is done.
+type Worker interface {
+	Start(context.Context) error
+	Shutdown(context.Context) error
+}

--- a/taskqueue/task_test.go
+++ b/taskqueue/task_test.go
@@ -253,6 +253,40 @@ func TestLogging_RecordsSuccessfulTask(t *testing.T) {
 	}
 }
 
+// Logging should include provider execution metadata when the worker adapter
+// supplies it through context, without requiring business payload changes.
+func TestLogging_RecordsExecutionInfo(t *testing.T) {
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&logs, nil))
+	processor := Chain(func(context.Context, Task) error {
+		return nil
+	}, Logging(logger))
+
+	task, err := NewJSONTask(Definition{Type: "document.review.v1", Queue: "reconcile"}, struct{}{})
+	if err != nil {
+		t.Fatalf("NewJSONTask: %v", err)
+	}
+	ctx := ContextWithExecutionInfo(context.Background(), NewExecutionInfo(
+		WithExecutionTaskID("provider-task-1"),
+		WithExecutionRetryCount(2),
+		WithExecutionMaxRetry(5),
+	))
+	if err := processor(ctx, task); err != nil {
+		t.Fatalf("processor: %v", err)
+	}
+
+	output := logs.String()
+	for _, want := range []string{
+		`"task_id":"provider-task-1"`,
+		`"retry_count":2`,
+		`"max_retry":5`,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("logs = %s, want %s", output, want)
+		}
+	}
+}
+
 // Logging should preserve the processor error while recording failure fields
 // so retry decisions stay unchanged and failures remain observable.
 func TestLogging_RecordsFailedTask(t *testing.T) {


### PR DESCRIPTION
## Summary
- add provider-neutral `taskqueue.ExecutionInfo` and context helpers for worker execution metadata
- include execution metadata in taskqueue logging middleware when providers supply it
- clarify `Runner` cancellation semantics and add `Worker` lifecycle interface for Start/Shutdown based runtime wiring

## Design notes
- execution metadata is carried through context and does not change task payload schemas
- retry count and max retry preserve explicit zero values separately from missing metadata
- worker lifecycle remains provider-neutral; no asynq-specific concepts are introduced in components

## Verification
- `go test ./taskqueue`
- `go test ./...`
- `make test`
- `make benchmark`
- `git diff --check`