### PR TITLE
docs: clarify message runner failure contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ resolution. It is not a broker topic, subject, queue, partition, or offset.
 Provider packages map `Kind`, `Message.ID`, `Message.Key`, `OccurredAt`, and
 headers into their own broker envelopes and own retry, DLQ, ack, and commit
 policy.
+
+`message.Handler.Handle` errors are message-level failures for one delivered
+message. `message.Runner.Run` errors are runtime-level failures for a provider
+loop; context shutdown returns `ctx.Err()`. Provider packages must document how
+message-level failures are retried, routed to DLQ, dropped, or otherwise
+recorded without treating every handler error as a runtime failure.

--- a/ddd/message/doc.go
+++ b/ddd/message/doc.go
@@ -14,6 +14,12 @@
 // polling, acknowledgement, offset commit, retry, redelivery, and dead-letter
 // routing belong to provider or application code.
 //
+// Handler failures and provider runtime failures are separate layers.
+// Handler.Handle returns message-level failures for one delivered integration
+// message. Runner.Run returns why a provider runtime loop terminated. Context
+// cancellation or expiration returns ctx.Err(); non-context Run errors mean the
+// runtime cannot continue safely.
+//
 // Message ID, Kind, OccurredAt, Key, and Headers are transport-neutral fields.
 // Providers decide how to encode them into their own envelopes. This package
 // intentionally does not define Kafka-style header names.

--- a/ddd/message/router.go
+++ b/ddd/message/router.go
@@ -15,10 +15,12 @@ type Publisher interface {
 // this handler. A provider may ack, commit, or otherwise mark delivery complete
 // after all matching handlers return nil.
 //
-// A non-nil error means the message was not successfully handled. Providers may
-// apply their own retry, redelivery, dead-letter, stop, or failure-recording
-// policy. Business failures that should not cause redelivery should be handled
-// inside the handler and then return nil.
+// A non-nil error is a message-level failure: this specific message was not
+// successfully handled. Providers may apply their own retry, redelivery,
+// dead-letter, drop, or failure-recording policy. A Handler error is not, by
+// itself, a Runner runtime-loop failure. Business outcomes that should not use
+// provider failure handling should be handled inside the handler and then
+// return nil.
 type Handler interface {
 	Listening() []Kind
 	Handle(context.Context, Message) error
@@ -37,6 +39,15 @@ type Subscriber interface {
 
 // Runner is an optional runtime loop capability for providers that actively
 // consume messages.
+//
+// Run blocks until the provider runtime loop terminates. If ctx is canceled or
+// expires, Run returns ctx.Err(). A non-context error returned by Run means the
+// provider runtime cannot continue safely, for example because polling,
+// acknowledgement, commit, or provider-owned failure handling failed.
+//
+// Run errors are runtime-level failures. Handler.Handle errors are message-level
+// failures and should be handled by the provider's documented message failure
+// policy rather than being treated as Run failures by default.
 type Runner interface {
 	Run(context.Context) error
 }

--- a/docs/project-knowledge/conventions.md
+++ b/docs/project-knowledge/conventions.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-05-10
+last_updated: 2026-06-01
 updated_by: superpowers-memory:update
 triggered_by_plan: 2026-05-10-integration-message.md
 ---
@@ -27,7 +27,8 @@ triggered_by_plan: 2026-05-10-integration-message.md
 - `ddd/message/outbox` is the reliability subpackage for integration-message outbox contracts and relay runtime; keep it separate from `ddd/message` core DTO/routing APIs and from `ddd/event`.
 - Broker-specific envelope, acknowledgement, DLQ, concrete store, and concrete broker adapter behavior should live outside both `ddd/message` and `ddd/message/outbox`.
 - `message.Kind` is a semantic message contract identifier, not a broker topic/subject/routing-key.
-- `message.Handler.Handle` returning `nil` means provider code may ack/commit; returning an error leaves retry, DLQ, redelivery, or stop policy to the provider/application.
+- `message.Handler.Handle` errors are message-level failures; provider packages must document retry, DLQ, drop, or failure-recording policy separately from `message.Runner.Run` runtime-loop termination.
+- `message.Runner.Run` returns `ctx.Err()` for context shutdown; non-context errors mean the provider runtime cannot continue safely.
 
 ## Git And CI
 

--- a/docs/project-knowledge/glossary.md
+++ b/docs/project-knowledge/glossary.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-05-10
+last_updated: 2026-06-01
 updated_by: superpowers-memory:update
 triggered_by_plan: 2026-05-10-integration-message.md
 ---
@@ -29,6 +29,8 @@ triggered_by_plan: 2026-05-10-integration-message.md
 **Publisher** — Capability interface that directly hands off an integration message to a messaging runtime. → `ddd/message/`
 
 **Subscriber** — Capability interface that registers integration message handlers. → `ddd/message/`
+
+**Runner** — Capability interface for provider runtime loops; `Run` reports loop termination, not ordinary handler failure. → `ddd/message/`
 
 **Router** — In-process integration message handler router keyed by message kind. → `ddd/message/`
 

--- a/docs/project-knowledge/index.md
+++ b/docs/project-knowledge/index.md
@@ -1,8 +1,8 @@
 ---
-last_updated: 2026-05-10
+last_updated: 2026-06-01
 updated_by: superpowers-memory:update
 triggered_by_plan: 2026-05-10-integration-message.md
-covers_branch: hotfix/enhance@fc2ec99
+covers_branch: codex/clarify-message-runner-contract@5a0a623
 ---
 
 # Project Knowledge Index
@@ -17,10 +17,10 @@ covers_branch: hotfix/enhance@fc2ec99
   Key points: `ddd/message` includes protobuf message construction, handler routing, and payload resolution; provider retry/DLQ/ack/commit remain outside core.
 
 - [conventions.md](conventions.md) — Coding, testing, event, message, and CI rules.
-  Key points: keep `mediator`, `ddd/event`, `ddd/message`, and `ddd/message/outbox` responsibilities separate; `message.Kind` is semantic, not a broker address.
+  Key points: keep `mediator`, `ddd/event`, `ddd/message`, and `ddd/message/outbox` responsibilities separate; `message.Handler.Handle` failures are message-level while `message.Runner.Run` reports runtime-loop termination.
 
 - [decisions.md](decisions.md) — Architecture decision summaries and known issues.
   Key points: DDD concepts live under `ddd/`; integration messages are protobuf DTOs separate from domain events.
 
 - [glossary.md](glossary.md) — Project terminology and package ownership.
-  Key points: defines domain event, integration message, message kind/key, payload resolver, publisher/subscriber/router, and outbox lifecycle terms.
+  Key points: defines domain event, integration message, message kind/key, payload resolver, publisher/subscriber/runner/router, and outbox lifecycle terms.


### PR DESCRIPTION
## Summary
- Clarify that `Handler.Handle` errors are message-level failures, not `Runner.Run` failures by themselves.
- Document `Runner.Run` shutdown semantics: context cancellation/expiration returns `ctx.Err()`; non-context errors indicate provider runtime failure.
- Update README and project knowledge entries to keep the `ddd/message` contract consistent.

## Verification
- `go test ./...`
- `node /home/xuhao/.codex/plugins/cache/skill-workshop-codex/superpowers-memory/1.12.30/hooks/codex-runtime.js verify`